### PR TITLE
Add IdP Initiated Login Field

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -15679,6 +15679,23 @@
         "Application"
       ]
     },
+    "OpenIdConnectApplicationIdpInitiatedLogin": {
+      "properties": {
+        "default_scope": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "mode": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-okta-tags": [
+        "Application"
+      ]
+    },
     "OpenIdConnectApplicationIssuerMode": {
       "enum": [
         "CUSTOM_URL",
@@ -15715,6 +15732,9 @@
             "$ref": "#/definitions/OAuthGrantType"
           },
           "type": "array"
+        },
+        "idp_initiated_login": {
+          "$ref": "#/definitions/OpenIdConnectApplicationIdpInitiatedLogin"
         },
         "initiate_login_uri": {
           "type": "string"

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -10036,6 +10036,17 @@ definitions:
     type: string
     x-okta-tags:
       - Application
+  OpenIdConnectApplicationIdpInitiatedLogin:
+    properties:
+      default_scope:
+        items:
+          type: string
+        type: array
+      mode:
+        type: string
+    type: object
+    x-okta-tags:
+      - Application
   OpenIdConnectApplicationIssuerMode:
     enum:
       - CUSTOM_URL
@@ -10061,6 +10072,8 @@ definitions:
         items:
           $ref: '#/definitions/OAuthGrantType'
         type: array
+      idp_initiated_login:
+        $ref: '#/definitions/OpenIdConnectApplicationIdpInitiatedLogin'
       initiate_login_uri:
         type: string
       issuer_mode:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -10026,6 +10026,8 @@ definitions:
         type: string
       issuer_mode:
         $ref: '#/definitions/OpenIdConnectApplicationIssuerMode'
+      idp_initiated_login:
+        $ref: '#/definitions/OpenIdConnectApplicationIdpInitiatedLogin'
       logo_uri:
         type: string
       policy_uri:
@@ -10048,6 +10050,17 @@ definitions:
         type: string
       jwks:
         $ref: '#/definitions/OpenIdConnectApplicationSettingsClientKeys'
+    x-okta-tags:
+      - Application
+  OpenIdConnectApplicationIdpInitiatedLogin:
+    properties:
+      mode:
+        type: string
+      default_scope:
+        items:
+          type: string
+        type: array
+    type: object
     x-okta-tags:
       - Application
   OpenIdConnectApplicationSettingsClientKeys:


### PR DESCRIPTION
Adding missing field into OAuth 2.0 client application 
- [OAuth 2.0 application settings](https://developer.okta.com/docs/reference/api/apps/#settings-10)
- [idp-initiated-login-object](https://developer.okta.com/docs/reference/api/apps/#idp-initiated-login-object)