### PR TITLE
OKTA-369793 Add ThreatInsight API to OpenAPI spec

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -7579,7 +7579,7 @@
           "200": {
             "description": "Success",
             "schema": {
-              "$ref": "#/definitions/ThreatInsightInformation"
+              "$ref": "#/definitions/ThreatInsightConfiguration"
             }
           }
         },
@@ -7615,7 +7615,7 @@
           "200": {
             "description": "Success",
             "schema": {
-              "$ref": "#/definitions/ThreatInsightInformation"
+              "$ref": "#/definitions/ThreatInsightConfiguration"
             }
           }
         },
@@ -10755,7 +10755,6 @@
           "type": "string"
         },
         "id": {
-          "readOnly": true,
           "type": "string"
         },
         "lastSync": {
@@ -18325,22 +18324,6 @@
     },
     "ThreatInsightConfiguration": {
       "properties": {
-        "action": {
-          "type": "string"
-        },
-        "excludeZones": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        }
-      },
-      "x-okta-tags": [
-        "ThreatInsight"
-      ]
-    },
-    "ThreatInsightInformation": {
-      "properties": {
         "_links": {
           "additionalProperties": {
             "type": "object"
@@ -18368,6 +18351,23 @@
           "type": "string"
         }
       },
+      "x-okta-crud": [
+        {
+          "alias": "read",
+          "arguments": [],
+          "operationId": "getThreatInsightConfiguration"
+        },
+        {
+          "alias": "update",
+          "arguments": [
+            {
+              "dest": "threatInsightConfiguration",
+              "self": true
+            }
+          ],
+          "operationId": "updateThreatInsightConfiguration"
+        }
+      ],
       "x-okta-tags": [
         "ThreatInsight"
       ]
@@ -19548,7 +19548,6 @@
           "type": "string"
         },
         "id": {
-          "readOnly": true,
           "type": "string"
         },
         "lastUpdated": {

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -7570,7 +7570,7 @@
           "application/json"
         ],
         "description": "Gets current ThreatInsight configuration",
-        "operationId": "getThreatInsightConfiguration",
+        "operationId": "getCurrentConfiguration",
         "parameters": [],
         "produces": [
           "application/json"
@@ -7597,7 +7597,7 @@
           "application/json"
         ],
         "description": "Updates ThreatInsight configuration",
-        "operationId": "updateThreatInsightConfiguration",
+        "operationId": "updateConfiguration",
         "parameters": [
           {
             "in": "body",
@@ -18355,7 +18355,7 @@
         {
           "alias": "read",
           "arguments": [],
-          "operationId": "getThreatInsightConfiguration"
+          "operationId": "getCurrentConfiguration"
         },
         {
           "alias": "update",
@@ -18365,7 +18365,7 @@
               "self": true
             }
           ],
-          "operationId": "updateThreatInsightConfiguration"
+          "operationId": "updateConfiguration"
         }
       ],
       "x-okta-tags": [

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -14721,6 +14721,7 @@
     "LogCredentialProvider": {
       "enum": [
         "OKTA_AUTHENTICATION_PROVIDER",
+        "OKTA_CREDENTIAL_PROVIDER",
         "RSA",
         "SYMANTEC",
         "GOOGLE",

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -7564,6 +7564,71 @@
         ]
       }
     },
+    "/api/v1/threats/configuration": {
+      "get": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Gets current ThreatInsight configuration",
+        "operationId": "getThreatInsightConfiguration",
+        "parameters": [],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/ThreatInsightInformation"
+            }
+          }
+        },
+        "security": [
+          {
+            "api_token": []
+          }
+        ],
+        "tags": [
+          "ThreatInsight"
+        ]
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Updates ThreatInsight configuration",
+        "operationId": "updateThreatInsightConfiguration",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "ThreatInsightConfiguration",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ThreatInsightConfiguration"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/ThreatInsightInformation"
+            }
+          }
+        },
+        "security": [
+          {
+            "api_token": []
+          }
+        ],
+        "tags": [
+          "ThreatInsight"
+        ]
+      }
+    },
     "/api/v1/trustedOrigins": {
       "get": {
         "consumes": [
@@ -10690,6 +10755,7 @@
           "type": "string"
         },
         "id": {
+          "readOnly": true,
           "type": "string"
         },
         "lastSync": {
@@ -18257,6 +18323,55 @@
         "User"
       ]
     },
+    "ThreatInsightConfiguration": {
+      "properties": {
+        "action": {
+          "type": "string"
+        },
+        "excludeZones": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "x-okta-tags": [
+        "ThreatInsight"
+      ]
+    },
+    "ThreatInsightInformation": {
+      "properties": {
+        "_links": {
+          "additionalProperties": {
+            "type": "object"
+          },
+          "readOnly": true,
+          "type": "object"
+        },
+        "action": {
+          "type": "string"
+        },
+        "created": {
+          "format": "date-time",
+          "readOnly": true,
+          "type": "string"
+        },
+        "excludeZones": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "lastUpdated": {
+          "format": "date-time",
+          "readOnly": true,
+          "type": "string"
+        }
+      },
+      "x-okta-tags": [
+        "ThreatInsight"
+      ]
+    },
     "TokenAuthorizationServerPolicyRuleAction": {
       "properties": {
         "accessTokenLifetimeMinutes": {
@@ -19433,6 +19548,7 @@
           "type": "string"
         },
         "id": {
+          "readOnly": true,
           "type": "string"
         },
         "lastUpdated": {

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -9365,6 +9365,7 @@ definitions:
   LogCredentialProvider:
     enum:
       - OKTA_AUTHENTICATION_PROVIDER
+      - OKTA_CREDENTIAL_PROVIDER
       - RSA
       - SYMANTEC
       - GOOGLE

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -4794,6 +4794,46 @@ paths:
       summary: Update SMS Template
       tags:
         - Template
+  /api/v1/threats/configuration:
+    get:
+      consumes:
+        - application/json
+      description: Gets current ThreatInsight configuration
+      operationId: getThreatInsightConfiguration
+      parameters: []
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/ThreatInsightInformation'
+      security:
+        - api_token: []
+      tags:
+        - ThreatInsight
+    post:
+      consumes:
+        - application/json
+      description: Updates ThreatInsight configuration
+      operationId: updateThreatInsightConfiguration
+      parameters:
+        - in: body
+          name: ThreatInsightConfiguration
+          required: true
+          schema:
+            $ref: '#/definitions/ThreatInsightConfiguration'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/ThreatInsightInformation'
+      security:
+        - api_token: []
+      tags:
+        - ThreatInsight
   /api/v1/trustedOrigins:
     get:
       consumes:
@@ -6851,6 +6891,7 @@ definitions:
         readOnly: true
         type: string
       id:
+        readOnly: true
         type: string
       lastSync:
         format: date-time
@@ -11722,6 +11763,39 @@ definitions:
         type: string
     x-okta-tags:
       - User
+  ThreatInsightConfiguration:
+    properties:
+      action:
+        type: string
+      excludeZones:
+        items:
+          type: string
+        type: array
+    x-okta-tags:
+      - ThreatInsight
+  ThreatInsightInformation:
+    properties:
+      _links:
+        additionalProperties:
+          type: object
+        readOnly: true
+        type: object
+      action:
+        type: string
+      created:
+        format: date-time
+        readOnly: true
+        type: string
+      excludeZones:
+        items:
+          type: string
+        type: array
+      lastUpdated:
+        format: date-time
+        readOnly: true
+        type: string
+    x-okta-tags:
+      - ThreatInsight
   TokenAuthorizationServerPolicyRuleAction:
     properties:
       accessTokenLifetimeMinutes:
@@ -12428,6 +12502,7 @@ definitions:
       displayName:
         type: string
       id:
+        readOnly: true
         type: string
       lastUpdated:
         format: date-time

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -4807,7 +4807,7 @@ paths:
         '200':
           description: Success
           schema:
-            $ref: '#/definitions/ThreatInsightInformation'
+            $ref: '#/definitions/ThreatInsightConfiguration'
       security:
         - api_token: []
       tags:
@@ -4829,7 +4829,7 @@ paths:
         '200':
           description: Success
           schema:
-            $ref: '#/definitions/ThreatInsightInformation'
+            $ref: '#/definitions/ThreatInsightConfiguration'
       security:
         - api_token: []
       tags:
@@ -6891,7 +6891,6 @@ definitions:
         readOnly: true
         type: string
       id:
-        readOnly: true
         type: string
       lastSync:
         format: date-time
@@ -11765,16 +11764,6 @@ definitions:
       - User
   ThreatInsightConfiguration:
     properties:
-      action:
-        type: string
-      excludeZones:
-        items:
-          type: string
-        type: array
-    x-okta-tags:
-      - ThreatInsight
-  ThreatInsightInformation:
-    properties:
       _links:
         additionalProperties:
           type: object
@@ -11794,6 +11783,15 @@ definitions:
         format: date-time
         readOnly: true
         type: string
+    x-okta-crud:
+      - alias: read
+        arguments: []
+        operationId: getThreatInsightConfiguration
+      - alias: update
+        arguments:
+          - dest: threatInsightConfiguration
+            self: true
+        operationId: updateThreatInsightConfiguration
     x-okta-tags:
       - ThreatInsight
   TokenAuthorizationServerPolicyRuleAction:
@@ -12502,7 +12500,6 @@ definitions:
       displayName:
         type: string
       id:
-        readOnly: true
         type: string
       lastUpdated:
         format: date-time

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -4799,7 +4799,7 @@ paths:
       consumes:
         - application/json
       description: Gets current ThreatInsight configuration
-      operationId: getThreatInsightConfiguration
+      operationId: getCurrentConfiguration
       parameters: []
       produces:
         - application/json
@@ -4816,7 +4816,7 @@ paths:
       consumes:
         - application/json
       description: Updates ThreatInsight configuration
-      operationId: updateThreatInsightConfiguration
+      operationId: updateConfiguration
       parameters:
         - in: body
           name: ThreatInsightConfiguration
@@ -11786,12 +11786,12 @@ definitions:
     x-okta-crud:
       - alias: read
         arguments: []
-        operationId: getThreatInsightConfiguration
+        operationId: getCurrentConfiguration
       - alias: update
         arguments:
           - dest: threatInsightConfiguration
             self: true
-        operationId: updateThreatInsightConfiguration
+        operationId: updateConfiguration
     x-okta-tags:
       - ThreatInsight
   TokenAuthorizationServerPolicyRuleAction:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -6707,7 +6707,7 @@ paths:
         - application/json
       description: >-
         Updates ThreatInsight configuration
-      operationId: updateThreatInsightConfiguration
+      operationId: updateConfiguration
       parameters:
         - in: body
           required: true
@@ -6728,7 +6728,7 @@ paths:
         - application/json
       description: >-
         Gets current ThreatInsight configuration
-      operationId: getThreatInsightConfiguration
+      operationId: getCurrentConfiguration
       parameters: []
       produces:
         - application/json
@@ -12629,12 +12629,12 @@ definitions:
     x-okta-crud:
       - alias: read
         arguments: []
-        operationId: getThreatInsightConfiguration
+        operationId: getCurrentConfiguration
       - alias: update
         arguments:
           - dest: threatInsightConfiguration
             self: true
-        operationId: updateThreatInsightConfiguration
+        operationId: updateConfiguration
     x-okta-tags:
       - ThreatInsight
 

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -9325,6 +9325,7 @@ definitions:
   LogCredentialProvider:
     enum:
       - OKTA_AUTHENTICATION_PROVIDER
+      - OKTA_CREDENTIAL_PROVIDER
       - RSA
       - SYMANTEC
       - GOOGLE

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -6718,7 +6718,7 @@ paths:
         '200':
           description: Success
           schema:
-            $ref: '#/definitions/ThreatInsightInformation'
+            $ref: '#/definitions/ThreatInsightConfiguration'
       security:
         - api_token: []
       tags:
@@ -6736,7 +6736,7 @@ paths:
         '200':
           description: Success
           schema:
-            $ref: '#/definitions/ThreatInsightInformation'
+            $ref: '#/definitions/ThreatInsightConfiguration'
       security:
         - api_token: []
       tags:
@@ -12607,16 +12607,6 @@ definitions:
       - Application
   ThreatInsightConfiguration:
     properties:
-      action:
-        type: string
-      excludeZones:
-        items:
-          type: string
-        type: array
-    x-okta-tags:
-      - ThreatInsight
-  ThreatInsightInformation:
-    properties:
       action: 
         type: string
       excludeZones:
@@ -12636,6 +12626,15 @@ definitions:
           type: object
         readOnly: true
         type: object
+    x-okta-crud:
+      - alias: read
+        arguments: []
+        operationId: getThreatInsightConfiguration
+      - alias: update
+        arguments:
+          - dest: threatInsightConfiguration
+            self: true
+        operationId: updateThreatInsightConfiguration
     x-okta-tags:
       - ThreatInsight
 

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -6701,6 +6701,46 @@ paths:
         - api_token: []
       tags:
         - User
+  '/api/v1/threats/configuration':
+    post:
+      consumes:
+        - application/json
+      description: >-
+        Updates ThreatInsight configuration
+      operationId: updateThreatInsightConfiguration
+      parameters:
+        - in: body
+          required: true
+          name: ThreatInsightConfiguration
+          schema:
+            $ref: '#/definitions/ThreatInsightConfiguration'
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/ThreatInsightInformation'
+      security:
+        - api_token: []
+      tags:
+        - ThreatInsight
+    get:
+      consumes:
+        - application/json
+      description: >-
+        Gets current ThreatInsight configuration
+      operationId: getThreatInsightConfiguration
+      parameters: []
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/ThreatInsightInformation'
+      security:
+        - api_token: []
+      tags:
+        - ThreatInsight
 definitions:
   ActivateFactorRequest:
     properties:
@@ -12565,3 +12605,37 @@ definitions:
     x-okta-parent: '#/definitions/ApplicationSettingsApplication'
     x-okta-tags:
       - Application
+  ThreatInsightConfiguration:
+    properties:
+      action:
+        type: string
+      excludeZones:
+        items:
+          type: string
+        type: array
+    x-okta-tags:
+      - ThreatInsight
+  ThreatInsightInformation:
+    properties:
+      action: 
+        type: string
+      excludeZones:
+        items:
+          type: string
+        type: array
+      created: 
+        format: date-time
+        readOnly: true
+        type: string
+      lastUpdated:
+        format: date-time
+        readOnly: true
+        type: string
+      _links:
+        additionalProperties:
+          type: object
+        readOnly: true
+        type: object
+    x-okta-tags:
+      - ThreatInsight
+


### PR DESCRIPTION
This endpoint is now GA and needs to be added to the spec: https://developer.okta.com/docs/reference/api/threat-insight/