### PR TITLE
Added missing tag

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -10998,6 +10998,9 @@
           {
             "api_token": []
           }
+        ],
+        "tags": [
+          "NetworkZone"
         ]
       },
       "post": {

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -7042,6 +7042,8 @@ paths:
             type: array
       security:
         - api_token: []
+      tags:
+        - NetworkZone
     post:
       consumes:
         - application/json

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -6948,6 +6948,8 @@ paths:
             items:
               $ref: '#/definitions/NetworkZone'
             type: array
+      tags:
+        - NetworkZone
     post:
       consumes:
         - application/json


### PR DESCRIPTION
This fixes the issue when generating SDK:
```
okta-sdk-python/openapi/templates/index.js:143
    let tag = operation.tags[0];
                            ^
TypeError: Cannot read property '0' of undefined
```