### PR TITLE
Interfaces need to be updated for compatibility with Java SDK

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -16592,6 +16592,7 @@
           "$ref": "#/definitions/OktaSignOnPolicyRuleSignonActions"
         }
       },
+      "x-okta-parent": "#/definitions/PolicyRuleActions",
       "x-okta-tags": [
         "Policy"
       ]
@@ -16608,6 +16609,7 @@
           "$ref": "#/definitions/PolicyPeopleCondition"
         }
       },
+      "x-okta-parent": "#/definitions/PolicyRuleConditions",
       "x-okta-tags": [
         "Policy"
       ]
@@ -17313,6 +17315,7 @@
           "$ref": "#/definitions/PasswordPolicyRuleAction"
         }
       },
+      "x-okta-parent": "#/definitions/PolicyRuleActions",
       "x-okta-tags": [
         "Policy"
       ]
@@ -17326,6 +17329,7 @@
           "$ref": "#/definitions/PolicyPeopleCondition"
         }
       },
+      "x-okta-parent": "#/definitions/PolicyRuleConditions",
       "x-okta-tags": [
         "Policy"
       ]

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -10609,6 +10609,7 @@ definitions:
     properties:
       signon:
         $ref: '#/definitions/OktaSignOnPolicyRuleSignonActions'
+    x-okta-parent: '#/definitions/PolicyRuleActions'
     x-okta-tags:
       - Policy
   OktaSignOnPolicyRuleConditions:
@@ -10619,6 +10620,7 @@ definitions:
         $ref: '#/definitions/PolicyNetworkCondition'
       people:
         $ref: '#/definitions/PolicyPeopleCondition'
+    x-okta-parent: '#/definitions/PolicyRuleConditions'
     x-okta-tags:
       - Policy
   OktaSignOnPolicyRuleSignonActions:
@@ -11093,6 +11095,7 @@ definitions:
         $ref: '#/definitions/PasswordPolicyRuleAction'
       selfServiceUnlock:
         $ref: '#/definitions/PasswordPolicyRuleAction'
+    x-okta-parent: '#/definitions/PolicyRuleActions'
     x-okta-tags:
       - Policy
   PasswordPolicyRuleConditions:
@@ -11101,6 +11104,7 @@ definitions:
         $ref: '#/definitions/PolicyNetworkCondition'
       people:
         $ref: '#/definitions/PolicyPeopleCondition'
+    x-okta-parent: '#/definitions/PolicyRuleConditions'
     x-okta-tags:
       - Policy
   PasswordPolicySettings:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -10720,6 +10720,7 @@ definitions:
     properties:
       signon:
         $ref: '#/definitions/OktaSignOnPolicyRuleSignonActions'
+    x-okta-parent: '#/definitions/PolicyRuleActions'
     x-okta-tags:
       - Policy
   OktaSignOnPolicyRuleConditions:
@@ -10730,6 +10731,7 @@ definitions:
         $ref: '#/definitions/PolicyNetworkCondition'
       people:
         $ref: '#/definitions/PolicyPeopleCondition'
+    x-okta-parent: '#/definitions/PolicyRuleConditions'
     x-okta-tags:
       - Policy
   OktaSignOnPolicyRuleSignonActions:
@@ -11204,6 +11206,7 @@ definitions:
         $ref: '#/definitions/PasswordPolicyRuleAction'
       selfServiceUnlock:
         $ref: '#/definitions/PasswordPolicyRuleAction'
+    x-okta-parent: '#/definitions/PolicyRuleActions'
     x-okta-tags:
       - Policy
   PasswordPolicyRuleConditions:
@@ -11212,6 +11215,7 @@ definitions:
         $ref: '#/definitions/PolicyNetworkCondition'
       people:
         $ref: '#/definitions/PolicyPeopleCondition'
+    x-okta-parent: '#/definitions/PolicyRuleConditions'
     x-okta-tags:
       - Policy
   PasswordPolicySettings:


### PR DESCRIPTION
Java supports covariant return types for overridden methods. This means an overridden method may have a more specific return type. That is, as long as the new return type is assignable to the return type of the method you are overriding, it's allowed.

That is why we need to have next changes:

- `OktaSignOnPolicyRuleActions` and `PasswordPolicyRuleActions` should implement `PolicyRuleActions`

- `OktaSignOnPolicyRuleConditions` and `PasswordPolicyRuleConditions` should implement `PolicyRuleConditions`

The Interface `OktaSignOnPolicyRule` extends `PolicyRule` interface.
The `PolicyRule` interface has property actions. A getter for this property should have a return type `PolicyRuleActions`.
The `OktaSignOnPolicyRule` also has property actions. A getter for this property should have the return type `OktaSignOnPolicyRuleActions`.
So the getter `getActions()` in `OktaSignOnPolicyRule` will override the getter `getActions()` in `PolicyRule`.
That is why `OktaSignOnPolicyRuleActions` should implement `PolicyRuleActions`.

Same logic for `PasswordPolicyRuleActions`, `OktaSignOnPolicyRuleConditions` and `PasswordPolicyRuleConditions`.