### PR TITLE
Response type for activateNetworkZone and deactivateNetworkZone

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -11264,7 +11264,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/NetworkZone"
+            }
           }
         },
         "security": [
@@ -11298,7 +11301,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/NetworkZone"
+            }
           }
         },
         "security": [

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -7210,6 +7210,8 @@ paths:
       responses:
         '200':
           description: Success
+          schema:
+            $ref: '#/definitions/NetworkZone'
       security:
         - api_token: []
       summary: Activate Network Zone
@@ -7231,6 +7233,8 @@ paths:
       responses:
         '200':
           description: Success
+          schema:
+            $ref: '#/definitions/NetworkZone'
       security:
         - api_token: []
       summary: Deactivate Network Zone

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -7106,6 +7106,8 @@ paths:
       responses:
         '200':
           description: Success
+          schema:
+            $ref: '#/definitions/NetworkZone'
       security:
         - api_token: [ ]
       summary: Deactivate Network Zone
@@ -7125,6 +7127,8 @@ paths:
       responses:
         '200':
           description: Success
+          schema:
+            $ref: '#/definitions/NetworkZone'
       security:
         - api_token: [ ]
       summary: Activate Network Zone


### PR DESCRIPTION
This PR solving an inconsistency in `activateNetworkZone` and `deactivateNetworkZone` methods syntax for the `NetworkZone` object in API.
openapi-spec describes the return type for this method as `void` but the actual call returning a `NetworkZone` object.

PR for Java Mgmt SDK: https://github.com/okta/okta-sdk-java/pull/572/files#diff-003145e24599013aff48cf944b56535ef1d263df510788d912f961d256dcbfbaR181-R188