### PR TITLE
Domain API: Java SDK compatibility fixes

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -13812,40 +13812,6 @@
         }
       },
       "type": "object",
-      "x-okta-crud": [
-        {
-          "alias": "delete",
-          "arguments": [
-            {
-              "dest": "domainId",
-              "src": "id"
-            }
-          ],
-          "operationId": "deleteDomain"
-        },
-        {
-          "alias": "read",
-          "arguments": [
-            {
-              "dest": "domainId",
-              "src": "id"
-            }
-          ],
-          "operationId": "getDomain"
-        }
-      ],
-      "x-okta-operations": [
-        {
-          "alias": "verify",
-          "arguments": [
-            {
-              "dest": "domainId",
-              "src": "id"
-            }
-          ],
-          "operationId": "verifyDomain"
-        }
-      ],
       "x-okta-tags": [
         "Domain"
       ]
@@ -13868,6 +13834,18 @@
           "type": "string"
         }
       },
+      "x-okta-operations": [
+        {
+          "alias": "createCertificate",
+          "arguments": [
+            {
+              "dest": "certificate",
+              "self": true
+            }
+          ],
+          "operationId": "createCertificate"
+        }
+      ],
       "x-okta-tags": [
         "Domain"
       ]

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -8773,23 +8773,6 @@ definitions:
       domain:
         type: string
     type: object
-    x-okta-crud:
-      - alias: delete
-        arguments:
-          - dest: domainId
-            src: id
-        operationId: deleteDomain
-      - alias: read
-        arguments:
-          - dest: domainId
-            src: id
-        operationId: getDomain
-    x-okta-operations:
-      - alias: verify
-        arguments:
-          - dest: domainId
-            src: id
-        operationId: verifyDomain
     x-okta-tags:
       - Domain
   DomainCertificate:
@@ -8804,6 +8787,12 @@ definitions:
         enum:
           - PEM
         type: string
+    x-okta-operations:
+      - alias: createCertificate
+        arguments:
+          - dest: certificate
+            self: true
+        operationId: createCertificate
     x-okta-tags:
       - Domain
   DomainCertificateMetadata:
@@ -9976,7 +9965,7 @@ definitions:
       x5t:
         readOnly: false
         type: string
-      'x5t#S256':
+      x5t#S256:
         readOnly: false
         type: string
       x5u:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -8490,23 +8490,6 @@ definitions:
       domain:
         type: string
     type: object
-    x-okta-crud:
-      - alias: delete
-        arguments:
-          - dest: domainId
-            src: id
-        operationId: deleteDomain
-      - alias: read
-        arguments:
-          - dest: domainId
-            src: id
-        operationId: getDomain
-    x-okta-operations:
-      - alias: verify
-        arguments:
-          - dest: domainId
-            src: id
-        operationId: verifyDomain
     x-okta-tags:
       - Domain
   DomainCertificate:
@@ -8525,6 +8508,12 @@ definitions:
           - PEM
         type:
           string
+    x-okta-operations:
+      - alias: createCertificate
+        arguments:
+          - dest: certificate
+            self: true
+        operationId: createCertificate
     x-okta-tags:
       - Domain
   DomainCertificateMetadata:


### PR DESCRIPTION
This PR related to [Add Domains API endpoints to open API spec. OKTA-387064](https://github.com/okta/okta-management-openapi-spec/pull/45) and [Update Domains API. OKTA-406710](https://github.com/okta/okta-management-openapi-spec/pull/48)

Operations `deleteDomain`, `getDomain` and `verifyDomain` could not be located inside a Domain object due the ID field is not exists in it.

The `createCertificate` operation should belong to the `DomainCertificate` object.