### PR TITLE
property naming fix

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -13810,7 +13810,7 @@
     },
     "Domain": {
       "properties": {
-        "certificateSourcetype": {
+        "certificateSourceType": {
           "$ref": "#/definitions/DomainCertificateSourceType"
         },
         "dnsRecords": {

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -8787,7 +8787,7 @@ definitions:
       - Policy
   Domain:
     properties:
-      certificateSourcetype:
+      certificateSourceType:
         $ref: '#/definitions/DomainCertificateSourceType'
       dnsRecords:
         items:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -8492,7 +8492,7 @@ definitions:
       id:
         type:
           string
-      certificateSourcetype:
+      certificateSourceType:
         $ref: '#/definitions/DomainCertificateSourceType'
       domain:
         type: string


### PR DESCRIPTION
Property name inconsistent with the [documentation](https://developer.okta.com/docs/reference/api/domains/#usage-examples)

`certificateSourceType` is a correct name