### PR TITLE
DomainListResponse is not defined in docs and could be removed

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -3251,7 +3251,10 @@
           "200": {
             "description": "Success",
             "schema": {
-              "$ref": "#/definitions/DomainListResponse"
+              "items": {
+                "$ref": "#/definitions/Domain"
+              },
+              "type": "array"
             }
           }
         },
@@ -13899,19 +13902,6 @@
         "PEM"
       ],
       "type": "string",
-      "x-okta-tags": [
-        "Domain"
-      ]
-    },
-    "DomainListResponse": {
-      "properties": {
-        "domains": {
-          "items": {
-            "$ref": "#/definitions/Domain"
-          },
-          "type": "array"
-        }
-      },
       "x-okta-tags": [
         "Domain"
       ]

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -2073,7 +2073,9 @@ paths:
         '200':
           description: Success
           schema:
-            $ref: '#/definitions/DomainListResponse'
+            items:
+              $ref: '#/definitions/Domain'
+            type: array
       security:
         - api_token: []
       summary: List Domains
@@ -8843,14 +8845,6 @@ definitions:
     enum:
       - PEM
     type: string
-    x-okta-tags:
-      - Domain
-  DomainListResponse:
-    properties:
-      domains:
-        items:
-          $ref: '#/definitions/Domain'
-        type: array
     x-okta-tags:
       - Domain
   DomainValidationStatus:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -7189,7 +7189,9 @@ paths:
         '200':
           description: Success
           schema:
-              $ref: '#/definitions/DomainListResponse'
+            items:
+              $ref: '#/definitions/Domain'
+            type: array
       security:
         - api_token: []
       summary: List Domains
@@ -8548,14 +8550,6 @@ definitions:
     enum:
       - PEM
     type: string
-    x-okta-tags:
-      - Domain
-  DomainListResponse:
-    properties:
-      domains:
-        items:
-          $ref: '#/definitions/Domain'
-        type: array
     x-okta-tags:
       - Domain
   DomainValidationStatus:


### PR DESCRIPTION
The response for the `listDomains()` method doesn't require a new object.
Code could be simplified. Documentation is [here](DomainListResponse)