### PR TITLE
Added missing field to the auth server policy rule

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -19882,11 +19882,25 @@
         "accessTokenLifetimeMinutes": {
           "type": "integer"
         },
+        "inlineHook": {
+          "$ref": "#/definitions/TokenAuthorizationServerPolicyRuleActionInlineHook"
+        },
         "refreshTokenLifetimeMinutes": {
           "type": "integer"
         },
         "refreshTokenWindowMinutes": {
           "type": "integer"
+        }
+      },
+      "type": "object",
+      "x-okta-tags": [
+        "AuthorizationServerPolicy"
+      ]
+    },
+    "TokenAuthorizationServerPolicyRuleActionInlineHook": {
+      "properties": {
+        "id": {
+          "type": "string"
         }
       },
       "type": "object",

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -25,7 +25,7 @@ info:
   license:
     name: Apache-2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
-  version: 2.5.0
+  version: 2.6.0
 externalDocs:
   description: Find more info here
   url: 'http://developer.okta.com/docs/api/getting_started/design_principles.html'
@@ -9974,7 +9974,7 @@ definitions:
       x5t:
         readOnly: false
         type: string
-      'x5t#S256':
+      x5t#S256:
         readOnly: false
         type: string
       x5u:
@@ -12773,10 +12773,19 @@ definitions:
     properties:
       accessTokenLifetimeMinutes:
         type: integer
+      inlineHook:
+        $ref: '#/definitions/TokenAuthorizationServerPolicyRuleActionInlineHook'
       refreshTokenLifetimeMinutes:
         type: integer
       refreshTokenWindowMinutes:
         type: integer
+    type: object
+    x-okta-tags:
+      - AuthorizationServerPolicy
+  TokenAuthorizationServerPolicyRuleActionInlineHook:
+    properties:
+      id:
+        type: string
     type: object
     x-okta-tags:
       - AuthorizationServerPolicy

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -9553,6 +9553,16 @@ definitions:
         type: integer
       refreshTokenWindowMinutes:
         type: integer
+      inlineHook:
+        $ref: '#/definitions/TokenAuthorizationServerPolicyRuleActionInlineHook'
+    type: object
+    x-okta-tags:
+      - AuthorizationServerPolicy
+  TokenAuthorizationServerPolicyRuleActionInlineHook:
+    properties:
+      id:
+        type: string
+        readOnly: false
     type: object
     x-okta-tags:
       - AuthorizationServerPolicy


### PR DESCRIPTION
 API response:
 ```
 "actions": {
            "token": {
                "accessTokenLifetimeMinutes": 60,
                "refreshTokenLifetimeMinutes": 0,
                "refreshTokenWindowMinutes": 10080,
                "inlineHook": {
                    "id": "cal10unah02MoSC5u0h8"
                }
            }
        }
 ```
 
![Screenshot 2021-08-09 at 17 09 50](https://user-images.githubusercontent.com/71279414/128721474-5491de24-116f-4114-8e2b-78bbfbf90b83.jpg)
