### PR TITLE
Fixed policies and reverted domains

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -3251,10 +3251,7 @@
           "200": {
             "description": "Success",
             "schema": {
-              "items": {
-                "$ref": "#/definitions/Domain"
-              },
-              "type": "array"
+              "$ref": "#/definitions/DomainListResponse"
             }
           }
         },
@@ -7349,7 +7346,7 @@
             "description": "Success",
             "schema": {
               "items": {
-                "$ref": "#/definitions/AuthorizationServerPolicy"
+                "$ref": "#/definitions/Policy"
               },
               "type": "array"
             }
@@ -13902,6 +13899,19 @@
         "PEM"
       ],
       "type": "string",
+      "x-okta-tags": [
+        "Domain"
+      ]
+    },
+    "DomainListResponse": {
+      "properties": {
+        "domains": {
+          "items": {
+            "$ref": "#/definitions/Domain"
+          },
+          "type": "array"
+        }
+      },
       "x-okta-tags": [
         "Domain"
       ]

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -2073,9 +2073,7 @@ paths:
         '200':
           description: Success
           schema:
-            items:
-              $ref: '#/definitions/Domain'
-            type: array
+            $ref: '#/definitions/DomainListResponse'
       security:
         - api_token: []
       summary: List Domains
@@ -4684,7 +4682,7 @@ paths:
           description: Success
           schema:
             items:
-              $ref: '#/definitions/AuthorizationServerPolicy'
+              $ref: '#/definitions/Policy'
             type: array
       security:
         - api_token: []
@@ -8845,6 +8843,14 @@ definitions:
     enum:
       - PEM
     type: string
+    x-okta-tags:
+      - Domain
+  DomainListResponse:
+    properties:
+      domains:
+        items:
+          $ref: '#/definitions/Domain'
+        type: array
     x-okta-tags:
       - Domain
   DomainValidationStatus:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -4481,7 +4481,7 @@ paths:
           description: Success
           schema:
             items:
-              $ref: '#/definitions/AuthorizationServerPolicy'
+              $ref: '#/definitions/Policy'
             type: array
       security:
         - api_token: []
@@ -7189,9 +7189,7 @@ paths:
         '200':
           description: Success
           schema:
-            items:
-              $ref: '#/definitions/Domain'
-            type: array
+            $ref: '#/definitions/DomainListResponse'
       security:
         - api_token: []
       summary: List Domains
@@ -8528,6 +8526,14 @@ definitions:
           - dest: certificate
             self: true
         operationId: createCertificate
+    x-okta-tags:
+      - Domain
+  DomainListResponse:
+    properties:
+      domains:
+        items:
+          $ref: '#/definitions/Domain'
+        type: array
     x-okta-tags:
       - Domain
   DomainCertificateMetadata:


### PR DESCRIPTION
 * `/api/v1/policies` now returns correct model `'#/definitions/Policy'` (instead of `"#/definitions/AuthorizationServerPolicy"`)
 * reverted changes regarding `DomainListResponse`