### PR TITLE
Improvements for Java SDK

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -18374,11 +18374,6 @@
       "type": "object",
       "x-okta-operations": [
         {
-          "alias": "getContactUser",
-          "arguments": [],
-          "operationId": "getOrgContactUser"
-        },
-        {
           "alias": "updateContactUser",
           "arguments": [
             {
@@ -18401,15 +18396,19 @@
           }
         },
         "optOutEmailUsers": {
+          "readOnly": true,
           "type": "boolean"
         }
       },
       "type": "object",
-      "x-okta-crud": [
+      "x-okta-operations": [
         {
-          "alias": "read",
-          "arguments": [],
-          "operationId": "getOktaCommunicationSettings"
+          "alias": "optInUsersToOktaCommunicationEmails",
+          "operationId": "optInUsersToOktaCommunicationEmails"
+        },
+        {
+          "alias": "optOutUsersFromOktaCommunicationEmails",
+          "operationId": "optOutUsersFromOktaCommunicationEmails"
         }
       ],
       "x-okta-tags": [
@@ -18435,13 +18434,29 @@
         },
         "expiration": {
           "format": "date-time",
+          "readOnly": true,
           "type": "string"
         },
         "support": {
-          "$ref": "#/definitions/OrgOktaSupportSetting"
+          "$ref": "#/definitions/OrgOktaSupportSetting",
+          "readOnly": true
         }
       },
       "type": "object",
+      "x-okta-operations": [
+        {
+          "alias": "extendOktaSupport",
+          "operationId": "extendOktaSupport"
+        },
+        {
+          "alias": "grantOktaSupport",
+          "operationId": "grantOktaSupport"
+        },
+        {
+          "alias": "revokeOktaSupport",
+          "operationId": "revokeOktaSupport"
+        }
+      ],
       "x-okta-tags": [
         "Org"
       ]
@@ -18454,10 +18469,21 @@
           }
         },
         "showEndUserFooter": {
+          "readOnly": true,
           "type": "boolean"
         }
       },
       "type": "object",
+      "x-okta-operations": [
+        {
+          "alias": "hideEndUserFooter",
+          "operationId": "hideOktaUIFooter"
+        },
+        {
+          "alias": "showEndUserFooter",
+          "operationId": "showOktaUIFooter"
+        }
+      ],
       "x-okta-tags": [
         "Org"
       ]

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -11782,9 +11782,6 @@ definitions:
         type: string
     type: object
     x-okta-operations:
-      - alias: getContactUser
-        arguments: []
-        operationId: getOrgContactUser
       - alias: updateContactUser
         arguments:
           - dest: userId
@@ -11798,12 +11795,14 @@ definitions:
         additionalProperties:
           type: object
       optOutEmailUsers:
+        readOnly: true
         type: boolean
     type: object
-    x-okta-crud:
-      - alias: read
-        arguments: []
-        operationId: getOktaCommunicationSettings
+    x-okta-operations:
+      - alias: optInUsersToOktaCommunicationEmails
+        operationId: optInUsersToOktaCommunicationEmails
+      - alias: optOutUsersFromOktaCommunicationEmails
+        operationId: optOutUsersFromOktaCommunicationEmails
     x-okta-tags:
       - Org
   OrgOktaSupportSetting:
@@ -11820,10 +11819,19 @@ definitions:
           type: object
       expiration:
         format: date-time
+        readOnly: true
         type: string
       support:
         $ref: '#/definitions/OrgOktaSupportSetting'
+        readOnly: true
     type: object
+    x-okta-operations:
+      - alias: extendOktaSupport
+        operationId: extendOktaSupport
+      - alias: grantOktaSupport
+        operationId: grantOktaSupport
+      - alias: revokeOktaSupport
+        operationId: revokeOktaSupport
     x-okta-tags:
       - Org
   OrgPreferences:
@@ -11832,8 +11840,14 @@ definitions:
         additionalProperties:
           type: object
       showEndUserFooter:
+        readOnly: true
         type: boolean
     type: object
+    x-okta-operations:
+      - alias: hideEndUserFooter
+        operationId: hideOktaUIFooter
+      - alias: showEndUserFooter
+        operationId: showOktaUIFooter
     x-okta-tags:
       - Org
   OrgSetting:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -10584,11 +10584,13 @@ definitions:
           type: object
       optOutEmailUsers:
         type: boolean
+        readOnly: true
     type: object
-    x-okta-crud:
-      - alias: read
-        arguments: []
-        operationId: getOktaCommunicationSettings
+    x-okta-operations:
+      - alias: optInUsersToOktaCommunicationEmails
+        operationId: optInUsersToOktaCommunicationEmails
+      - alias: optOutUsersFromOktaCommunicationEmails
+        operationId: optOutUsersFromOktaCommunicationEmails
     x-okta-tags:
       - Org
   OrgContactTypeObj:
@@ -10623,9 +10625,6 @@ definitions:
         type: string
     type: object
     x-okta-operations:
-      - alias: getContactUser
-        arguments: []
-        operationId: getOrgContactUser
       - alias: updateContactUser
         arguments:
           - dest: userId
@@ -10710,9 +10709,18 @@ definitions:
       expiration:
         format: date-time
         type: string
+        readOnly: true
       support:
         $ref: '#/definitions/OrgOktaSupportSetting'
+        readOnly: true
     type: object
+    x-okta-operations:
+      - alias: extendOktaSupport
+        operationId: extendOktaSupport
+      - alias: grantOktaSupport
+        operationId: grantOktaSupport
+      - alias: revokeOktaSupport
+        operationId: revokeOktaSupport
     x-okta-tags:
       - Org
   OrgPreferences:
@@ -10722,7 +10730,13 @@ definitions:
           type: object
       showEndUserFooter:
         type: boolean
+        readOnly: true
     type: object
+    x-okta-operations:
+      - alias: hideEndUserFooter
+        operationId: hideOktaUIFooter
+      - alias: showEndUserFooter
+        operationId: showOktaUIFooter
     x-okta-tags:
       - Org
   UserIdString:


### PR DESCRIPTION
List of changes:

- Method `getContactUser` should belong to `client`
- Methods `optInUsersToOktaCommunicationEmails` and `optOutUsersFromOktaCommunicationEmails` should belong to `OrgOktaCommunicationSetting`
- Methods `extendOktaSupport`, `grantOktaSupport` and `revokeOktaSupport` should belong to `OrgOktaSupportSettingsObj`
- Methods `hideEndUserFooter` and `showEndUserFooter` should belong to `OrgPreferences`