### PR TITLE
Migrate from oas2 to oas3

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -81,38 +81,50 @@ function buildOperations(spec) {
 
   function buildOperation(pathName, methodName, method) {
     const operation = buildOperationObject(pathName, methodName, method);
-    const body = method.parameters.find(param => param.in === 'body');
+    const body = method['requestBody'];
     if (body) {
-      if (body.schema) {
-        operation.bodyModel = getModelName(body.schema['$ref']);
-      }
-      if (!body.schema && body.type) {
-        operation.bodyModel = body.type
+      // Check solution with 'application/json'
+      // TODO: support any type, any schema, oneOf/allOf/anyOf
+      const body_content = body.content['application/json'];
+      if (body_content) {
+        if (body_content.schema) {
+          operation.bodyModel = getModelName(body_content.schema['$ref']);
+        }
+        if (!body_content.schema && body_content.type) {
+          operation.bodyModel = body_content.type
 
-        if (body.format) {
-          operation.bodyFormat = body.format
+          if (body_content.format) {
+            operation.bodyFormat = body_content.format
+          }
         }
       }
     }
     // Determine the return type
-    const success = _.get(method, 'responses["200"].schema') || _.get(method, 'responses["201"].schema');
+    const success = _.get(method, 'responses["200"].content') || _.get(method, 'responses["201"].content');
     if (success) {
-      if (success.items && success.items['$ref']) {
-        operation.responseModel = getModelName(success.items['$ref']);
-        operation.isArray = true;
-        /* istanbul ignore else */
-      }
-      else if (success['$ref']) {
-        operation.responseModel = getModelName(success['$ref']);
-      }
-      else if (success['type']) {
-        operation.returnType = success['type']
+      // TODO: add support for other content-types
+      resp_json = success["application/json"];
+      if (resp_json) {
+          if (resp_json.schema.items && resp_json.schema.items['$ref']) {
+            operation.responseModel = getModelName(resp_json.schema.items['$ref']);
+            operation.isArray = true;
+            /* istanbul ignore else */
+          }
+          else if (resp_json.schema['$ref']) {
+            operation.responseModel = getModelName(resp_json.schema['$ref']);
+          }
+          else if (resp_json.schema['type']) {
+            operation.returnType = resp_json.schema['type']
+          }
       }
     }
     return operation;
   }
 
   function buildOperationObject(pathName, methodName, method) {
+    if (method.parameters == null) {
+        method.parameters = [];
+    }
     return Object.assign({
       path: pathName,
       method: methodName,
@@ -143,105 +155,128 @@ function buildModels(spec, operations) {
   const operationMap = _.keyBy(operations, 'operationId');
 
   // Track enums
-  const enumArray = Object.entries(spec.definitions)
+  const enumArray = Object.entries(spec.components.schemas)
     .filter(([definitionName, definition]) => !!definition.enum)
     .map(([definitionName, definition]) => definitionName);
+
   const enumSet = new Set(enumArray);
 
-  return Object.entries(spec.definitions)
+  let models = [];
+
+    function create_new_model(definitionName, definition, operationMap, enumSet) {
+          const model = {
+            modelName: definitionName
+          };
+
+          if (definition.enum) {
+            model.enum = definition.enum;
+            model.tags = definition['x-okta-tags'] || /* istanbul ignore next */ [];
+            return model;
+          }
+
+          model.properties = Object.entries(definition.properties || {})
+            .map(([propertyName, property]) => {
+              const prop = _.cloneDeep(property);
+              prop.propertyName = propertyName;
+
+              if (property['$ref'] && enumSet.has(getModelName(property['$ref']))) {
+                prop.commonType = 'enum';
+              } else {
+                prop.commonType = util.getCommonType(property);
+              }
+
+              switch (prop.commonType) {
+                case 'hash':
+                  prop.isHash = true;
+                  break;
+                case 'array':
+                  prop.isArray = true;
+                  break;
+                case 'object':
+                  prop.isObject = true;
+                  break;
+                case 'enum':
+                  prop.isEnum = true;
+                  break;
+              }
+
+              if (['hash', 'array', 'object', 'enum'].includes(prop.commonType)) {
+                model_type = getModelType(property);
+                if (model_type === 'object') {
+                  if (property.items && property.items['properties']) {
+                      nested_model_name = definitionName + _.upperFirst(propertyName);
+                      nested_model = create_new_model(nested_model_name, property.items, operationMap, enumSet);
+                      models.push(nested_model);
+                      prop.model = nested_model_name;
+                  }
+                  else {
+                    prop.model = model_type;
+                  }
+                } else {
+                  prop.model = model_type;
+                }
+              }
+
+              delete prop.type;
+              delete prop.format;
+              delete prop.items;
+              delete prop.additionalProperties;
+
+              return prop;
+            });
+
+          model.methods = (definition['x-okta-operations'] || []).map(link => {
+            return {
+              alias: link.alias,
+              arguments: link.arguments,
+              operation: operationMap[link.operationId]
+            };
+          });
+
+          model.crud = (definition['x-okta-crud'] || []).map(link => {
+            return {
+              alias: link.alias,
+              arguments: link.arguments,
+              operation: operationMap[link.operationId]
+            };
+          });
+
+          model.tags = definition['x-okta-tags'] || /* istanbul ignore next */ [];
+
+          model.isExtensible = definition['x-okta-extensible'] || /* istanbul ignore next */ false;
+
+          if (definition['discriminator'] && definition['discriminator'].mapping) {
+            model.requiresResolution = true;
+          }
+
+          const parentDefinitionUri = definition['x-okta-parent'];
+
+          if (parentDefinitionUri) {
+            const parentModelName = parentDefinitionUri.split('/')[3];
+            model.extends = parentModelName;
+          }
+
+          const discriminatorDefinition = definition['discriminator'];
+          if (discriminatorDefinition && discriminatorDefinition.mapping) {
+            model.resolutionStrategy = {
+              propertyName: discriminatorDefinition.propertyName,
+              valueToModelMapping: Object.entries(discriminatorDefinition.mapping).reduce((mapping, keyValuePair) => {
+                mapping[keyValuePair[0]] = keyValuePair[1].split('/')[3];
+                return mapping;
+              }, {})
+            };
+          }
+
+          return model;
+    }
+
+  Object.entries(spec.components.schemas)
     .map(([definitionName, definition]) => {
-      const model = {
-        modelName: definitionName
-      };
-
-      if (definition.enum) {
-        model.enum = definition.enum;
-        model.tags = definition['x-okta-tags'] || /* istanbul ignore next */ [];
-        return model;
-      }
-
-      model.properties = Object.entries(definition.properties || {})
-        .map(([propertyName, property]) => {
-          const prop = _.cloneDeep(property);
-          prop.propertyName = propertyName;
-
-          if (property['$ref'] && enumSet.has(getModelName(property['$ref']))) {
-            prop.commonType = 'enum';
-          } else {
-            prop.commonType = util.getCommonType(property);
-          }
-
-          switch (prop.commonType) {
-            case 'hash':
-              prop.isHash = true;
-              break;
-            case 'array':
-              prop.isArray = true;
-              break;
-            case 'object':
-              prop.isObject = true;
-              break;
-            case 'enum':
-              prop.isEnum = true;
-              break;
-          }
-
-          if (['hash', 'array', 'object', 'enum'].includes(prop.commonType)) {
-            prop.model = getModelType(property);
-          }
-
-          delete prop.type;
-          delete prop.format;
-          delete prop.items;
-          delete prop.additionalProperties;
-
-          return prop;
-        });
-
-      model.methods = (definition['x-okta-operations'] || []).map(link => {
-        return {
-          alias: link.alias,
-          arguments: link.arguments,
-          operation: operationMap[link.operationId]
-        };
-      });
-
-      model.crud = (definition['x-okta-crud'] || []).map(link => {
-        return {
-          alias: link.alias,
-          arguments: link.arguments,
-          operation: operationMap[link.operationId]
-        };
-      });
-
-      model.tags = definition['x-okta-tags'] || /* istanbul ignore next */ [];
-
-      model.isExtensible = definition['x-okta-extensible'] || /* istanbul ignore next */ false;
-
-      if (definition['x-openapi-v3-discriminator']) {
-        model.requiresResolution = true;
-      }
-
-      const parentDefinitionUri = definition['x-okta-parent'];
-
-      if (parentDefinitionUri) {
-        const parentModelName = parentDefinitionUri.split('/')[2];
-        model.extends = parentModelName;
-      }
-
-      const discriminatorDefinition = definition['x-openapi-v3-discriminator'];
-      if (discriminatorDefinition) {
-        model.resolutionStrategy = {
-          propertyName: discriminatorDefinition.propertyName,
-          valueToModelMapping: Object.entries(discriminatorDefinition.mapping).reduce((mapping, keyValuePair) => {
-            mapping[keyValuePair[0]] = keyValuePair[1].split('/')[2];
-            return mapping;
-          }, {})
-        };
-      }
-
-      return model;
+      const model = create_new_model(definitionName, definition, operationMap, enumSet);
+      models.push(model);
     });
+
+  return models;
 }
 
 function main() {


### PR DESCRIPTION
Initial draft. Request body and response support only 'application/json' content-type. Need to support all content types and special cases (oneOf/allOf/anyOf).

Test run with current change against Python SDK (ITs and UTs): 6 failed, 258 passed 