### PR TITLE
Correct `CUSTOM_URL` `IdentityProvider.issuerMode` value

### DIFF
--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -9826,7 +9826,7 @@ definitions:
       issuerMode:
         enum:
           - ORG_URL
-          - CUSTOM_URL_DOMAIN
+          - CUSTOM_URL
         type: string
       lastUpdated:
         format: date-time


### PR DESCRIPTION
Based on the [docs](https://developer.okta.com/docs/reference/api/idps/#example), `issuerMode` should be one of:
- `ORG_URL`
- `CUSTOM_URL`

This matches other similar enums in the spec

**NOTE:** This is a breaking API change for static languages.  Static languages _could_ work around this by manually adding via mixin the old value with a different string value, for example:

```java
CUSTOM_URL_DOMAIN("CUSTOM_URL")
```

Also, note, I did NOT test the spec generation or downstream SDKs with this change.