### PR TITLE
fix missing return type issue with authenticators api

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -1681,7 +1681,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Authenticator"
+            }
           }
         },
         "security": [
@@ -1714,7 +1717,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Authenticator"
+            }
           }
         },
         "security": [

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -1089,6 +1089,8 @@ paths:
       responses:
         '200':
           description: Success
+          schema:
+            $ref: '#/definitions/Authenticator'
       security:
         - api_token: []
       tags:
@@ -1109,6 +1111,8 @@ paths:
       responses:
         '200':
           description: Success
+          schema:
+            $ref: '#/definitions/Authenticator'
       security:
         - api_token: []
       tags:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -1071,6 +1071,8 @@ paths:
       responses:
         '200':
           description: Success
+          schema:
+            $ref: '#/definitions/Authenticator'
       security:
         - api_token: []
       tags:
@@ -1091,6 +1093,8 @@ paths:
       responses:
         '200':
           description: Success
+          schema:
+            $ref: '#/definitions/Authenticator'
       security:
         - api_token: []
       tags:


### PR DESCRIPTION
### Issue:

Per [API doc](https://developer.okta.com/docs/reference/api/authenticators-admin/#activate-an-authenticator), `activate` and `deactivate` authenticator must return `Authenticator` object type. But the current version of the spec does not define so. 

### Earlier:

```
    /**
    * 
    * Success
    */
    @javax.annotation.Generated(
            value    = "com.okta.swagger.codegen.OktaJavaClientApiCodegen",
            date     = "2021-09-22T09:27:54.778-05:00",
            comments = "POST - /api/v1/authenticators/{authenticatorId}/lifecycle/activate")
    void activate();


    /**
    * 
    * Success
    */
    @javax.annotation.Generated(
            value    = "com.okta.swagger.codegen.OktaJavaClientApiCodegen",
            date     = "2021-09-22T09:27:54.778-05:00",
            comments = "POST - /api/v1/authenticators/{authenticatorId}/lifecycle/deactivate")
    void deactivate();
```

### Now:

```
    @javax.annotation.Generated(
            value    = "com.okta.swagger.codegen.OktaJavaClientApiCodegen",
            date     = "2021-09-23T13:52:22.912-05:00",
            comments = "POST - /api/v1/authenticators/{authenticatorId}/lifecycle/activate")
    Authenticator activate();


    /**
    * 
    * Success
    * @return Authenticator
    */
    @javax.annotation.Generated(
            value    = "com.okta.swagger.codegen.OktaJavaClientApiCodegen",
            date     = "2021-09-23T13:52:22.912-05:00",
            comments = "POST - /api/v1/authenticators/{authenticatorId}/lifecycle/deactivate")
    Authenticator deactivate();
```

Java SDK IT PR reference: https://github.com/okta/okta-sdk-java/pull/625
