### PR TITLE
Correct `CUSTOM_URL` `IdentityProvider.issuerMode` value

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -15944,7 +15944,7 @@
         "issuerMode": {
           "enum": [
             "ORG_URL",
-            "CUSTOM_URL_DOMAIN"
+            "CUSTOM_URL"
           ],
           "type": "string"
         },

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -10168,7 +10168,7 @@ definitions:
       issuerMode:
         enum:
           - ORG_URL
-          - CUSTOM_URL_DOMAIN
+          - CUSTOM_URL
         type: string
       lastUpdated:
         format: date-time

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -9826,7 +9826,7 @@ definitions:
       issuerMode:
         enum:
           - ORG_URL
-          - CUSTOM_URL_DOMAIN
+          - CUSTOM_URL
         type: string
       lastUpdated:
         format: date-time


### PR DESCRIPTION
Java SDK generated code:

Earlier:

```
    /**
    * Enum issuerMode
    */
    public enum IssuerModeEnum {
        ORG_URL("ORG_URL"),
        
        CUSTOM_URL_DOMAIN("CUSTOM_URL_DOMAIN");

        private String value;

        IssuerModeEnum(String value) {
            this.value = value;
        }

        @Override
        public String toString() {
            return String.valueOf(value);
        }
    }
```

Now:

```
    /**
    * Enum issuerMode
    */
    public enum IssuerModeEnum {
        ORG_URL("ORG_URL"),
        
        CUSTOM_URL("CUSTOM_URL");

        private String value;

        IssuerModeEnum(String value) {
            this.value = value;
        }

        @Override
        public String toString() {
            return String.valueOf(value);
        }
    }
```