### PR TITLE
Crud defs for orgs

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -13,7 +13,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "2.7.2"
+    "version": "2.8.0"
   },
   "externalDocs": {
     "description": "Find more info here",

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -18465,6 +18465,28 @@
         }
       },
       "type": "object",
+      "x-okta-crud": [
+        {
+          "alias": "read",
+          "arguments": [],
+          "operationId": "getOrgOktaSupportSettings"
+        },
+        {
+          "alias": "grant",
+          "arguments": [],
+          "operationId": "grantOktaSupport"
+        },
+        {
+          "alias": "extend",
+          "arguments": [],
+          "operationId": "extendOktaSupport"
+        },
+        {
+          "alias": "revoke",
+          "arguments": [],
+          "operationId": "revokeOktaSupport"
+        }
+      ],
       "x-okta-operations": [
         {
           "alias": "extendOktaSupport",

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -18423,6 +18423,23 @@
         }
       },
       "type": "object",
+      "x-okta-crud": [
+        {
+          "alias": "read",
+          "arguments": [],
+          "operationId": "getOktaCommunicationSettings"
+        },
+        {
+          "alias": "optin",
+          "arguments": [],
+          "operationId": "optInUsersToOktaCommunicationEmails"
+        },
+        {
+          "alias": "optout",
+          "arguments": [],
+          "operationId": "optOutUsersFromOktaCommunicationEmails"
+        }
+      ],
       "x-okta-operations": [
         {
           "alias": "optInUsersToOktaCommunicationEmails",

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -18535,6 +18535,23 @@
         }
       },
       "type": "object",
+      "x-okta-crud": [
+        {
+          "alias": "read",
+          "arguments": [],
+          "operationId": "getOrgPreferences"
+        },
+        {
+          "alias": "showfooter",
+          "arguments": [],
+          "operationId": "showOktaUIFooter"
+        },
+        {
+          "alias": "hidefooter",
+          "arguments": [],
+          "operationId": "hideOktaUIFooter"
+        }
+      ],
       "x-okta-operations": [
         {
           "alias": "hideEndUserFooter",

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -18559,6 +18559,11 @@
       "type": "object",
       "x-okta-crud": [
         {
+          "alias": "read",
+          "arguments": [],
+          "operationId": "getOrgSettings"
+        },
+        {
           "alias": "update",
           "arguments": [
             {

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -18372,6 +18372,28 @@
         }
       },
       "type": "object",
+      "x-okta-crud": [
+        {
+          "alias": "read",
+          "arguments": [
+            {
+              "dest": "contactType",
+              "src": "id"
+            }
+          ],
+          "operationId": "getOrgContactUser"
+        },
+        {
+          "alias": "update",
+          "arguments": [
+            {
+              "dest": "orgContactUser",
+              "self": true
+            }
+          ],
+          "operationId": "updateOrgContactUser"
+        }
+      ],
       "x-okta-operations": [
         {
           "alias": "updateContactUser",

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -7651,7 +7651,7 @@
         ],
         "summary": "Get org contact types",
         "tags": [
-          "Org"
+          "OrgContactTypeObj"
         ]
       }
     },
@@ -7688,7 +7688,7 @@
         ],
         "summary": "Get org contact user",
         "tags": [
-          "Org"
+          "OrgContactUser"
         ]
       },
       "put": {
@@ -7731,7 +7731,7 @@
         ],
         "summary": "Update org contact user",
         "tags": [
-          "Org"
+          "OrgContactUser"
         ]
       }
     },
@@ -7761,7 +7761,7 @@
         ],
         "summary": "Get org preferences",
         "tags": [
-          "Org"
+          "OrgPreferences"
         ]
       }
     },
@@ -7791,7 +7791,7 @@
         ],
         "summary": "Show Okta UI Footer",
         "tags": [
-          "Org"
+          "OrgPreferences"
         ]
       }
     },
@@ -7821,7 +7821,7 @@
         ],
         "summary": "Show Okta UI Footer",
         "tags": [
-          "Org"
+          "OrgPreferences"
         ]
       }
     },
@@ -7851,7 +7851,7 @@
         ],
         "summary": "Get Okta Communication Settings",
         "tags": [
-          "Org"
+          "OrgOktaCommunicationSetting"
         ]
       }
     },
@@ -7881,7 +7881,7 @@
         ],
         "summary": "Opt in all users to Okta Communication emails",
         "tags": [
-          "Org"
+          "OrgOktaCommunicationSetting"
         ]
       }
     },
@@ -7911,7 +7911,7 @@
         ],
         "summary": "Opt out all users from Okta Communication emails",
         "tags": [
-          "Org"
+          "OrgOktaCommunicationSetting"
         ]
       }
     },
@@ -7941,7 +7941,7 @@
         ],
         "summary": "Get Okta Support settings",
         "tags": [
-          "Org"
+          "OrgOktaSupportSettingsObj"
         ]
       }
     },
@@ -7971,7 +7971,7 @@
         ],
         "summary": "Extend Okta Support",
         "tags": [
-          "Org"
+          "OrgOktaSupportSettingsObj"
         ]
       }
     },
@@ -8001,7 +8001,7 @@
         ],
         "summary": "Grant Okta Support",
         "tags": [
-          "Org"
+          "OrgOktaSupportSettingsObj"
         ]
       }
     },
@@ -8031,7 +8031,7 @@
         ],
         "summary": "Extend Okta Support",
         "tags": [
-          "Org"
+          "OrgOktaSupportSettingsObj"
         ]
       }
     },

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -25,7 +25,7 @@ info:
   license:
     name: Apache-2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
-  version: 2.7.2
+  version: 2.8.0
 externalDocs:
   description: Find more info here
   url: 'https://developer.okta.com/docs/api/getting_started/design_principles.html'

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -4873,7 +4873,7 @@ paths:
         - api_token: []
       summary: Get org contact types
       tags:
-        - Org
+        - OrgContactTypeObj
   '/api/v1/org/contacts/{contactType}':
     get:
       consumes:
@@ -4898,7 +4898,7 @@ paths:
         - api_token: []
       summary: Get org contact user
       tags:
-        - Org
+        - OrgContactUser
     put:
       consumes:
         - application/json
@@ -4925,7 +4925,7 @@ paths:
         - api_token: []
       summary: Update org contact user
       tags:
-        - Org
+        - OrgContactUser
   /api/v1/org/preferences:
     get:
       consumes:
@@ -4944,7 +4944,7 @@ paths:
         - api_token: []
       summary: Get org preferences
       tags:
-        - Org
+        - OrgPreferences
   /api/v1/org/preferences/hideEndUserFooter:
     post:
       consumes:
@@ -4963,7 +4963,7 @@ paths:
         - api_token: []
       summary: Show Okta UI Footer
       tags:
-        - Org
+        - OrgPreferences
   /api/v1/org/preferences/showEndUserFooter:
     post:
       consumes:
@@ -4982,7 +4982,7 @@ paths:
         - api_token: []
       summary: Show Okta UI Footer
       tags:
-        - Org
+        - OrgPreferences
   /api/v1/org/privacy/oktaCommunication:
     get:
       consumes:
@@ -5001,7 +5001,7 @@ paths:
         - api_token: []
       summary: Get Okta Communication Settings
       tags:
-        - Org
+        - OrgOktaCommunicationSetting
   /api/v1/org/privacy/oktaCommunication/optIn:
     post:
       consumes:
@@ -5020,7 +5020,7 @@ paths:
         - api_token: []
       summary: Opt in all users to Okta Communication emails
       tags:
-        - Org
+        - OrgOktaCommunicationSetting
   /api/v1/org/privacy/oktaCommunication/optOut:
     post:
       consumes:
@@ -5039,7 +5039,7 @@ paths:
         - api_token: []
       summary: Opt out all users from Okta Communication emails
       tags:
-        - Org
+        - OrgOktaCommunicationSetting
   /api/v1/org/privacy/oktaSupport:
     get:
       consumes:
@@ -5058,7 +5058,7 @@ paths:
         - api_token: []
       summary: Get Okta Support settings
       tags:
-        - Org
+        - OrgOktaSupportSettingsObj
   /api/v1/org/privacy/oktaSupport/extend:
     post:
       consumes:
@@ -5079,7 +5079,7 @@ paths:
         - api_token: []
       summary: Extend Okta Support
       tags:
-        - Org
+        - OrgOktaSupportSettingsObj
   /api/v1/org/privacy/oktaSupport/grant:
     post:
       consumes:
@@ -5100,7 +5100,7 @@ paths:
         - api_token: []
       summary: Grant Okta Support
       tags:
-        - Org
+        - OrgOktaSupportSettingsObj
   /api/v1/org/privacy/oktaSupport/revoke:
     post:
       consumes:
@@ -5119,7 +5119,7 @@ paths:
         - api_token: []
       summary: Extend Okta Support
       tags:
-        - Org
+        - OrgOktaSupportSettingsObj
   /api/v1/policies:
     get:
       consumes:

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -11878,6 +11878,16 @@ definitions:
         readOnly: true
         type: boolean
     type: object
+    x-okta-crud:
+      - alias: read
+        arguments: []
+        operationId: getOrgPreferences
+      - alias: showfooter
+        arguments: []
+        operationId: showOktaUIFooter
+      - alias: hidefooter
+        arguments: []
+        operationId: hideOktaUIFooter
     x-okta-operations:
       - alias: hideEndUserFooter
         operationId: hideOktaUIFooter

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -11837,6 +11837,19 @@ definitions:
         $ref: '#/definitions/OrgOktaSupportSetting'
         readOnly: true
     type: object
+    x-okta-crud:
+      - alias: read
+        arguments: []
+        operationId: getOrgOktaSupportSettings
+      - alias: grant
+        arguments: []
+        operationId: grantOktaSupport
+      - alias: extend
+        arguments: []
+        operationId: extendOktaSupport
+      - alias: revoke
+        arguments: []
+        operationId: revokeOktaSupport
     x-okta-operations:
       - alias: extendOktaSupport
         operationId: extendOktaSupport

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -11810,6 +11810,16 @@ definitions:
         readOnly: true
         type: boolean
     type: object
+    x-okta-crud:
+      - alias: read
+        arguments: []
+        operationId: getOktaCommunicationSettings
+      - alias: optin
+        arguments: []
+        operationId: optInUsersToOktaCommunicationEmails
+      - alias: optout
+        arguments: []
+        operationId: optOutUsersFromOktaCommunicationEmails
     x-okta-operations:
       - alias: optInUsersToOktaCommunicationEmails
         operationId: optInUsersToOktaCommunicationEmails

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -11782,6 +11782,17 @@ definitions:
       userId:
         type: string
     type: object
+    x-okta-crud:
+      - alias: read
+        arguments:
+          - dest: contactType
+            src: id
+        operationId: getOrgContactUser
+      - alias: update
+        arguments:
+          - dest: orgContactUser
+            self: true
+        operationId: updateOrgContactUser
     x-okta-operations:
       - alias: updateContactUser
         arguments:

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -10693,7 +10693,7 @@ definitions:
       x5t:
         readOnly: false
         type: string
-      'x5t#S256':
+      x5t#S256:
         readOnly: false
         type: string
       x5u:
@@ -11901,6 +11901,9 @@ definitions:
         type: string
     type: object
     x-okta-crud:
+      - alias: read
+        arguments: []
+        operationId: getOrgSettings
       - alias: update
         arguments:
           - dest: orgSetting

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/openapi",
-  "version": "2.8.0",
+  "version": "2.7.2",
   "description": "Utilities to generate OpenAPI specifications for the Okta API",
   "main": "./dist/spec.json",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/openapi",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "description": "Utilities to generate OpenAPI specifications for the Okta API",
   "main": "./dist/spec.json",
   "bin": {

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -4655,7 +4655,7 @@ paths:
         - api_token: []
       summary: Get org contact types
       tags:
-        - Org
+        - OrgContactTypeObj
   '/api/v1/org/contacts/{contactType}':
     get:
       consumes:
@@ -4676,7 +4676,7 @@ paths:
         - api_token: []
       summary: Get org contact user
       tags:
-        - Org
+        - OrgContactUser
     put:
       consumes:
         - application/json
@@ -4701,7 +4701,7 @@ paths:
         - api_token: []
       summary: Update org contact user
       tags:
-        - Org
+        - OrgContactUser
   /api/v1/org/privacy/oktaSupport:
     get:
       consumes:
@@ -4718,7 +4718,7 @@ paths:
         - api_token: []
       summary: Get Okta Support settings
       tags:
-        - Org
+        - OrgOktaSupportSettingsObj
   /api/v1/org/privacy/oktaSupport/grant:
     post:
       consumes:
@@ -4737,7 +4737,7 @@ paths:
         - api_token: []
       summary: Grant Okta Support
       tags:
-        - Org
+        - OrgOktaSupportSettingsObj
   /api/v1/org/privacy/oktaSupport/extend:
     post:
       consumes:
@@ -4756,7 +4756,7 @@ paths:
         - api_token: []
       summary: Extend Okta Support
       tags:
-        - Org
+        - OrgOktaSupportSettingsObj
   /api/v1/org/privacy/oktaSupport/revoke:
     post:
       consumes:
@@ -4773,7 +4773,7 @@ paths:
         - api_token: []
       summary: Extend Okta Support
       tags:
-        - Org
+        - OrgOktaSupportSettingsObj
   /api/v1/org/privacy/oktaCommunication:
     get:
       consumes:
@@ -4790,7 +4790,7 @@ paths:
         - api_token: []
       summary: Get Okta Communication Settings
       tags:
-        - Org
+        - OrgOktaCommunicationSetting
   /api/v1/org/privacy/oktaCommunication/optOut:
     post:
       consumes:
@@ -4807,7 +4807,7 @@ paths:
         - api_token: []
       summary: Opt out all users from Okta Communication emails
       tags:
-        - Org
+        - OrgOktaCommunicationSetting
   /api/v1/org/privacy/oktaCommunication/optIn:
     post:
       consumes:
@@ -4824,7 +4824,7 @@ paths:
         - api_token: []
       summary: Opt in all users to Okta Communication emails
       tags:
-        - Org
+        - OrgOktaCommunicationSetting
   /api/v1/org/preferences:
     get:
       consumes:
@@ -4841,7 +4841,7 @@ paths:
         - api_token: []
       summary: Get org preferences
       tags:
-        - Org
+        - OrgPreferences
   /api/v1/org/preferences/showEndUserFooter:
     post:
       consumes:
@@ -4858,7 +4858,7 @@ paths:
         - api_token: []
       summary: Show Okta UI Footer
       tags:
-        - Org
+        - OrgPreferences
   /api/v1/org/preferences/hideEndUserFooter:
     post:
       consumes:
@@ -4875,7 +4875,7 @@ paths:
         - api_token: []
       summary: Show Okta UI Footer
       tags:
-        - Org
+        - OrgPreferences
   /api/v1/policies:
     get:
       consumes:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -10683,6 +10683,9 @@ definitions:
         type: string
     type: object
     x-okta-crud:
+      - alias: read
+        arguments: []
+        operationId: getOrgSettings
       - alias: update
         arguments:
           - dest: orgSetting

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -10738,6 +10738,19 @@ definitions:
         operationId: revokeOktaSupport
     x-okta-tags:
       - Org
+    x-okta-crud:
+      - alias: read
+        arguments: []
+        operationId: getOrgOktaSupportSettings
+      - alias: grant
+        arguments: []
+        operationId: grantOktaSupport
+      - alias: extend
+        arguments: []
+        operationId: extendOktaSupport
+      - alias: revoke
+        arguments: []
+        operationId: revokeOktaSupport
   OrgPreferences:
     properties:
       _links:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -10631,6 +10631,17 @@ definitions:
           - dest: userId
             src: userId
         operationId: updateOrgContactUser
+    x-okta-crud:
+      - alias: read
+        arguments:
+          - dest: contactType
+            src: id
+        operationId: getOrgContactUser
+      - alias: update
+        arguments:
+          - dest: orgContactUser
+            self: true
+        operationId: updateOrgContactUser
     x-okta-tags:
       - Org
   OrgSetting:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -10777,6 +10777,16 @@ definitions:
         operationId: showOktaUIFooter
     x-okta-tags:
       - Org
+    x-okta-crud:
+      - alias: read
+        arguments: []
+        operationId: getOrgPreferences
+      - alias: showfooter
+        arguments: []
+        operationId: showOktaUIFooter
+      - alias: hidefooter
+        arguments: []
+        operationId: hideOktaUIFooter
   UserIdString:
     properties:
       userId:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -10598,6 +10598,16 @@ definitions:
         operationId: optOutUsersFromOktaCommunicationEmails
     x-okta-tags:
       - Org
+    x-okta-crud:
+      - alias: read
+        arguments: []
+        operationId: getOktaCommunicationSettings
+      - alias: optin
+        arguments: []
+        operationId: optInUsersToOktaCommunicationEmails
+      - alias: optout
+        arguments: []
+        operationId: optOutUsersFromOktaCommunicationEmails
   OrgContactTypeObj:
     properties:
       _links:


### PR DESCRIPTION
Adds `x-okta-crud` definitions to the new resources interacting with the `/api/v1/org` endpoints. This allows the okta-sdk-golang (and other okta language sdk's?) to generate related resource methods.

okta-sdk-golang branch consuming these spec changes:
https://github.com/okta/okta-sdk-golang/pull/260