### PR TITLE
Put org operations on org settings crud.

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -18560,6 +18560,16 @@
       "type": "object",
       "x-okta-crud": [
         {
+          "alias": "read",
+          "arguments": [
+            {
+              "dest": "orgSetting",
+              "self": true
+            }
+          ],
+          "operationId": "getOrgSettings"
+        },
+        {
           "alias": "update",
           "arguments": [
             {
@@ -18578,6 +18588,136 @@
             }
           ],
           "operationId": "partialUpdateOrgSetting"
+        },
+        {
+          "alias": "contactTypes",
+          "arguments": [
+            {
+              "dest": "orgSetting",
+              "self": true
+            }
+          ],
+          "operationId": "getOrgContactTypes"
+        },
+        {
+          "alias": "contactUser",
+          "arguments": [
+            {
+              "dest": "orgSetting",
+              "self": true
+            }
+          ],
+          "operationId": "getOrgContactUser"
+        },
+        {
+          "alias": "updateContactUser",
+          "arguments": [
+            {
+              "dest": "orgSetting",
+              "self": true
+            }
+          ],
+          "operationId": "updateOrgContactUser"
+        },
+        {
+          "alias": "supportSettings",
+          "arguments": [
+            {
+              "dest": "orgSetting",
+              "self": true
+            }
+          ],
+          "operationId": "getOrgOktaSupportSettings"
+        },
+        {
+          "alias": "grantSupport",
+          "arguments": [
+            {
+              "dest": "orgSetting",
+              "self": true
+            }
+          ],
+          "operationId": "grantOktaSupport"
+        },
+        {
+          "alias": "extendSupport",
+          "arguments": [
+            {
+              "dest": "orgSetting",
+              "self": true
+            }
+          ],
+          "operationId": "extendOktaSupport"
+        },
+        {
+          "alias": "revokeSupport",
+          "arguments": [
+            {
+              "dest": "orgSetting",
+              "self": true
+            }
+          ],
+          "operationId": "revokeOktaSupport"
+        },
+        {
+          "alias": "communicationSettings",
+          "arguments": [
+            {
+              "dest": "orgSetting",
+              "self": true
+            }
+          ],
+          "operationId": "getOktaCommunicationSettings"
+        },
+        {
+          "alias": "optOutCommunications",
+          "arguments": [
+            {
+              "dest": "orgSetting",
+              "self": true
+            }
+          ],
+          "operationId": "optOutUsersFromOktaCommunicationEmails"
+        },
+        {
+          "alias": "optInCommunications",
+          "arguments": [
+            {
+              "dest": "orgSetting",
+              "self": true
+            }
+          ],
+          "operationId": "optInUsersToOktaCommunicationEmails"
+        },
+        {
+          "alias": "orgPreferences",
+          "arguments": [
+            {
+              "dest": "orgSetting",
+              "self": true
+            }
+          ],
+          "operationId": "getOrgPreferences"
+        },
+        {
+          "alias": "showFooter",
+          "arguments": [
+            {
+              "dest": "orgSetting",
+              "self": true
+            }
+          ],
+          "operationId": "showOktaUIFooter"
+        },
+        {
+          "alias": "hideFooter",
+          "arguments": [
+            {
+              "dest": "orgSetting",
+              "self": true
+            }
+          ],
+          "operationId": "hideOktaUIFooter"
         }
       ],
       "x-okta-tags": [

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -11902,6 +11902,11 @@ definitions:
         type: string
     type: object
     x-okta-crud:
+      - alias: read
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: getOrgSettings
       - alias: update
         arguments:
           - dest: orgSetting
@@ -11912,6 +11917,71 @@ definitions:
           - dest: orgSetting
             self: true
         operationId: partialUpdateOrgSetting
+      - alias: contactTypes
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: getOrgContactTypes
+      - alias: contactUser
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: getOrgContactUser
+      - alias: updateContactUser
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: updateOrgContactUser
+      - alias: supportSettings
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: getOrgOktaSupportSettings
+      - alias: grantSupport
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: grantOktaSupport
+      - alias: extendSupport
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: extendOktaSupport
+      - alias: revokeSupport
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: revokeOktaSupport
+      - alias: communicationSettings
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: getOktaCommunicationSettings
+      - alias: optOutCommunications
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: optOutUsersFromOktaCommunicationEmails
+      - alias: optInCommunications
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: optInUsersToOktaCommunicationEmails
+      - alias: orgPreferences
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: getOrgPreferences
+      - alias: showFooter
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: showOktaUIFooter
+      - alias: hideFooter
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: hideOktaUIFooter
     x-okta-tags:
       - Org
   PasswordCredential:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -10684,6 +10684,11 @@ definitions:
         type: string
     type: object
     x-okta-crud:
+      - alias: read
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: getOrgSettings
       - alias: update
         arguments:
           - dest: orgSetting
@@ -10694,6 +10699,71 @@ definitions:
           - dest: orgSetting
             self: true
         operationId: partialUpdateOrgSetting
+      - alias: contactTypes
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: getOrgContactTypes
+      - alias: contactUser
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: getOrgContactUser
+      - alias: updateContactUser
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: updateOrgContactUser
+      - alias: supportSettings
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: getOrgOktaSupportSettings
+      - alias: grantSupport
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: grantOktaSupport
+      - alias: extendSupport
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: extendOktaSupport
+      - alias: revokeSupport
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: revokeOktaSupport
+      - alias: communicationSettings
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: getOktaCommunicationSettings
+      - alias: optOutCommunications
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: optOutUsersFromOktaCommunicationEmails
+      - alias: optInCommunications
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: optInUsersToOktaCommunicationEmails
+      - alias: orgPreferences
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: getOrgPreferences
+      - alias: showFooter
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: showOktaUIFooter
+      - alias: hideFooter
+        arguments:
+          - dest: orgSetting
+            self: true
+        operationId: hideOktaUIFooter
     x-okta-tags:
       - Org
   OrgOktaSupportSetting:


### PR DESCRIPTION
Putting org operations on org settings crud.
Needed for okta-sdk-golang to be able to have methods for `/api/v1/org` and `/api/v1/org/*`

Corresponds to okta-sdk-golang PR https://github.com/okta/okta-sdk-golang/pull/261