### PR TITLE
Adds `x-okta-known-values` to Identity Providers

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -15990,7 +15990,19 @@
             "AgentlessDSSO",
             "X509"
           ],
-          "type": "string"
+          "type": "string",
+          "x-okta-known-values": [
+            "SAML2",
+            "GOOGLE",
+            "FACEBOOK",
+            "LINKEDIN",
+            "MICROSOFT",
+            "OIDC",
+            "OKTA",
+            "IWA",
+            "AgentlessDSSO",
+            "X509"
+          ]
         }
       },
       "type": "object",

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -10204,6 +10204,17 @@ definitions:
           - AgentlessDSSO
           - X509
         type: string
+        x-okta-known-values:
+          - SAML2
+          - GOOGLE
+          - FACEBOOK
+          - LINKEDIN
+          - MICROSOFT
+          - OIDC
+          - OKTA
+          - IWA
+          - AgentlessDSSO
+          - X509
     type: object
     x-okta-crud:
       - alias: create

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -9862,6 +9862,17 @@ definitions:
           - IWA
           - AgentlessDSSO
           - X509
+        x-okta-known-values:
+          - SAML2
+          - GOOGLE
+          - FACEBOOK
+          - LINKEDIN
+          - MICROSOFT
+          - OIDC
+          - OKTA
+          - IWA
+          - AgentlessDSSO
+          - X509
         type: string
     type: object
     x-okta-crud:


### PR DESCRIPTION
This PR adds an additional property to the `Identity Providers` model. 

To maintain backwards compatibility, this PR only adds the addition of `x-okta-known-values` for an enum type that can also be dynamic.

```yaml
x-okta-known-values:
          - SAML2
          - GOOGLE
          - ...
```

Doing this instead of changing `enum` allows generators to opt into this change. Your generator should check for the existance of `x-okta-known-values` on an enum field. if it exists, you may allow this to no longer be an enum when generating the SDK, but rather use a string value. You can then use the known values list to help the end user determine what values are expected here, as well as the freeform string.