### PR TITLE
Updates x-okta-operations for OrgSettings model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 Running changelog of releases since `2.2.3`
 
+## 2.8.1
+### Additions
+- Adds `x-okta-operations` to the `OrgSettings` model
 ## 2.8.0
 
 ### Additions

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -18386,18 +18386,6 @@
         }
       },
       "type": "object",
-      "x-okta-operations": [
-        {
-          "alias": "updateContactUser",
-          "arguments": [
-            {
-              "dest": "userId",
-              "src": "userId"
-            }
-          ],
-          "operationId": "updateOrgContactUser"
-        }
-      ],
       "x-okta-tags": [
         "Org"
       ]
@@ -18415,16 +18403,6 @@
         }
       },
       "type": "object",
-      "x-okta-operations": [
-        {
-          "alias": "optInUsersToOktaCommunicationEmails",
-          "operationId": "optInUsersToOktaCommunicationEmails"
-        },
-        {
-          "alias": "optOutUsersFromOktaCommunicationEmails",
-          "operationId": "optOutUsersFromOktaCommunicationEmails"
-        }
-      ],
       "x-okta-tags": [
         "Org"
       ]
@@ -18457,20 +18435,6 @@
         }
       },
       "type": "object",
-      "x-okta-operations": [
-        {
-          "alias": "extendOktaSupport",
-          "operationId": "extendOktaSupport"
-        },
-        {
-          "alias": "grantOktaSupport",
-          "operationId": "grantOktaSupport"
-        },
-        {
-          "alias": "revokeOktaSupport",
-          "operationId": "revokeOktaSupport"
-        }
-      ],
       "x-okta-tags": [
         "Org"
       ]
@@ -18488,16 +18452,6 @@
         }
       },
       "type": "object",
-      "x-okta-operations": [
-        {
-          "alias": "hideEndUserFooter",
-          "operationId": "hideOktaUIFooter"
-        },
-        {
-          "alias": "showEndUserFooter",
-          "operationId": "showOktaUIFooter"
-        }
-      ],
       "x-okta-tags": [
         "Org"
       ]
@@ -18598,38 +18552,26 @@
           "alias": "partialUpdate",
           "arguments": [
             {
-              "dest": "authenticatorId",
-              "src": "id"
+              "dest": "orgSetting",
+              "self": true
             }
           ],
           "operationId": "partialUpdateOrgSetting"
         },
         {
-          "alias": "contactTypes",
+          "alias": "getContactTypes",
           "operationId": "getOrgContactTypes"
         },
         {
-          "alias": "contactUser",
-          "arguments": [
-            {
-              "dest": "contactType",
-              "src": "type"
-            }
-          ],
+          "alias": "getOrgContactUser",
           "operationId": "getOrgContactUser"
         },
         {
           "alias": "updateContactUser",
-          "arguments": [
-            {
-              "dest": "userId",
-              "src": "id"
-            }
-          ],
           "operationId": "updateOrgContactUser"
         },
         {
-          "alias": "supportSettings",
+          "alias": "getSupportSettings",
           "operationId": "getOrgOktaSupportSettings"
         },
         {
@@ -18645,7 +18587,7 @@
           "operationId": "revokeOktaSupport"
         },
         {
-          "alias": "communicationSettings",
+          "alias": "getCommunicationSettings",
           "operationId": "getOktaCommunicationSettings"
         },
         {
@@ -18657,7 +18599,7 @@
           "operationId": "optInUsersToOktaCommunicationEmails"
         },
         {
-          "alias": "orgPreferences",
+          "alias": "getOrgPreferences",
           "operationId": "getOrgPreferences"
         },
         {
@@ -22252,6 +22194,7 @@
         }
       },
       "type": "object",
+      "x-okta-parent": "#/definitions/OrgContactUser",
       "x-okta-tags": [
         "Org"
       ]

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -18386,6 +18386,18 @@
         }
       },
       "type": "object",
+      "x-okta-operations": [
+        {
+          "alias": "updateContactUser",
+          "arguments": [
+            {
+              "dest": "userId",
+              "src": "userId"
+            }
+          ],
+          "operationId": "updateOrgContactUser"
+        }
+      ],
       "x-okta-tags": [
         "Org"
       ]
@@ -18403,6 +18415,16 @@
         }
       },
       "type": "object",
+      "x-okta-operations": [
+        {
+          "alias": "optInUsersToOktaCommunicationEmails",
+          "operationId": "optInUsersToOktaCommunicationEmails"
+        },
+        {
+          "alias": "optOutUsersFromOktaCommunicationEmails",
+          "operationId": "optOutUsersFromOktaCommunicationEmails"
+        }
+      ],
       "x-okta-tags": [
         "Org"
       ]
@@ -18435,6 +18457,20 @@
         }
       },
       "type": "object",
+      "x-okta-operations": [
+        {
+          "alias": "extendOktaSupport",
+          "operationId": "extendOktaSupport"
+        },
+        {
+          "alias": "grantOktaSupport",
+          "operationId": "grantOktaSupport"
+        },
+        {
+          "alias": "revokeOktaSupport",
+          "operationId": "revokeOktaSupport"
+        }
+      ],
       "x-okta-tags": [
         "Org"
       ]
@@ -18452,6 +18488,16 @@
         }
       },
       "type": "object",
+      "x-okta-operations": [
+        {
+          "alias": "hideEndUserFooter",
+          "operationId": "hideOktaUIFooter"
+        },
+        {
+          "alias": "showEndUserFooter",
+          "operationId": "showOktaUIFooter"
+        }
+      ],
       "x-okta-tags": [
         "Org"
       ]
@@ -18567,48 +18613,16 @@
           "operationId": "getOrgContactUser"
         },
         {
-          "alias": "updateContactUser",
-          "operationId": "updateOrgContactUser"
-        },
-        {
           "alias": "getSupportSettings",
           "operationId": "getOrgOktaSupportSettings"
         },
         {
-          "alias": "grantSupport",
-          "operationId": "grantOktaSupport"
-        },
-        {
-          "alias": "extendSupport",
-          "operationId": "extendOktaSupport"
-        },
-        {
-          "alias": "revokeSupport",
-          "operationId": "revokeOktaSupport"
-        },
-        {
-          "alias": "getCommunicationSettings",
+          "alias": "communicationSettings",
           "operationId": "getOktaCommunicationSettings"
         },
         {
-          "alias": "optOutCommunications",
-          "operationId": "optOutUsersFromOktaCommunicationEmails"
-        },
-        {
-          "alias": "optInCommunications",
-          "operationId": "optInUsersToOktaCommunicationEmails"
-        },
-        {
-          "alias": "getOrgPreferences",
+          "alias": "orgPreferences",
           "operationId": "getOrgPreferences"
-        },
-        {
-          "alias": "showFooter",
-          "operationId": "showOktaUIFooter"
-        },
-        {
-          "alias": "hideFooter",
-          "operationId": "hideOktaUIFooter"
         }
       ],
       "x-okta-tags": [

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -13,7 +13,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "2.8.0"
+    "version": "2.8.1"
   },
   "externalDocs": {
     "description": "Find more info here",
@@ -18591,33 +18591,29 @@
             }
           ],
           "operationId": "updateOrgSetting"
-        },
+        }
+      ],
+      "x-okta-operations": [
         {
           "alias": "partialUpdate",
           "arguments": [
             {
-              "dest": "orgSetting",
-              "self": true
+              "dest": "authenticatorId",
+              "src": "id"
             }
           ],
           "operationId": "partialUpdateOrgSetting"
         },
         {
           "alias": "contactTypes",
-          "arguments": [
-            {
-              "dest": "orgSetting",
-              "self": true
-            }
-          ],
           "operationId": "getOrgContactTypes"
         },
         {
           "alias": "contactUser",
           "arguments": [
             {
-              "dest": "orgSetting",
-              "self": true
+              "dest": "contactType",
+              "src": "type"
             }
           ],
           "operationId": "getOrgContactUser"
@@ -18626,110 +18622,50 @@
           "alias": "updateContactUser",
           "arguments": [
             {
-              "dest": "orgSetting",
-              "self": true
+              "dest": "userId",
+              "src": "id"
             }
           ],
           "operationId": "updateOrgContactUser"
         },
         {
           "alias": "supportSettings",
-          "arguments": [
-            {
-              "dest": "orgSetting",
-              "self": true
-            }
-          ],
           "operationId": "getOrgOktaSupportSettings"
         },
         {
           "alias": "grantSupport",
-          "arguments": [
-            {
-              "dest": "orgSetting",
-              "self": true
-            }
-          ],
           "operationId": "grantOktaSupport"
         },
         {
           "alias": "extendSupport",
-          "arguments": [
-            {
-              "dest": "orgSetting",
-              "self": true
-            }
-          ],
           "operationId": "extendOktaSupport"
         },
         {
           "alias": "revokeSupport",
-          "arguments": [
-            {
-              "dest": "orgSetting",
-              "self": true
-            }
-          ],
           "operationId": "revokeOktaSupport"
         },
         {
           "alias": "communicationSettings",
-          "arguments": [
-            {
-              "dest": "orgSetting",
-              "self": true
-            }
-          ],
           "operationId": "getOktaCommunicationSettings"
         },
         {
           "alias": "optOutCommunications",
-          "arguments": [
-            {
-              "dest": "orgSetting",
-              "self": true
-            }
-          ],
           "operationId": "optOutUsersFromOktaCommunicationEmails"
         },
         {
           "alias": "optInCommunications",
-          "arguments": [
-            {
-              "dest": "orgSetting",
-              "self": true
-            }
-          ],
           "operationId": "optInUsersToOktaCommunicationEmails"
         },
         {
           "alias": "orgPreferences",
-          "arguments": [
-            {
-              "dest": "orgSetting",
-              "self": true
-            }
-          ],
           "operationId": "getOrgPreferences"
         },
         {
           "alias": "showFooter",
-          "arguments": [
-            {
-              "dest": "orgSetting",
-              "self": true
-            }
-          ],
           "operationId": "showOktaUIFooter"
         },
         {
           "alias": "hideFooter",
-          "arguments": [
-            {
-              "dest": "orgSetting",
-              "self": true
-            }
-          ],
           "operationId": "hideOktaUIFooter"
         }
       ],

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -25,7 +25,7 @@ info:
   license:
     name: Apache-2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
-  version: 2.8.0
+  version: 2.8.1
 externalDocs:
   description: Find more info here
   url: 'https://developer.okta.com/docs/api/getting_started/design_principles.html'
@@ -11924,75 +11924,43 @@ definitions:
           - dest: orgSetting
             self: true
         operationId: updateOrgSetting
+    x-okta-operations:
       - alias: partialUpdate
         arguments:
-          - dest: orgSetting
-            self: true
+          - dest: authenticatorId
+            src: id
         operationId: partialUpdateOrgSetting
       - alias: contactTypes
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: getOrgContactTypes
       - alias: contactUser
         arguments:
-          - dest: orgSetting
-            self: true
+          - dest: contactType
+            src: type
         operationId: getOrgContactUser
       - alias: updateContactUser
         arguments:
-          - dest: orgSetting
-            self: true
+          - dest: userId
+            src: id
         operationId: updateOrgContactUser
       - alias: supportSettings
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: getOrgOktaSupportSettings
       - alias: grantSupport
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: grantOktaSupport
       - alias: extendSupport
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: extendOktaSupport
       - alias: revokeSupport
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: revokeOktaSupport
       - alias: communicationSettings
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: getOktaCommunicationSettings
       - alias: optOutCommunications
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: optOutUsersFromOktaCommunicationEmails
       - alias: optInCommunications
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: optInUsersToOktaCommunicationEmails
       - alias: orgPreferences
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: getOrgPreferences
       - alias: showFooter
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: showOktaUIFooter
       - alias: hideFooter
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: hideOktaUIFooter
     x-okta-tags:
       - Org

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -11795,12 +11795,6 @@ definitions:
       userId:
         type: string
     type: object
-    x-okta-operations:
-      - alias: updateContactUser
-        arguments:
-          - dest: userId
-            src: userId
-        operationId: updateOrgContactUser
     x-okta-tags:
       - Org
   OrgOktaCommunicationSetting:
@@ -11812,11 +11806,6 @@ definitions:
         readOnly: true
         type: boolean
     type: object
-    x-okta-operations:
-      - alias: optInUsersToOktaCommunicationEmails
-        operationId: optInUsersToOktaCommunicationEmails
-      - alias: optOutUsersFromOktaCommunicationEmails
-        operationId: optOutUsersFromOktaCommunicationEmails
     x-okta-tags:
       - Org
   OrgOktaSupportSetting:
@@ -11839,13 +11828,6 @@ definitions:
         $ref: '#/definitions/OrgOktaSupportSetting'
         readOnly: true
     type: object
-    x-okta-operations:
-      - alias: extendOktaSupport
-        operationId: extendOktaSupport
-      - alias: grantOktaSupport
-        operationId: grantOktaSupport
-      - alias: revokeOktaSupport
-        operationId: revokeOktaSupport
     x-okta-tags:
       - Org
   OrgPreferences:
@@ -11857,11 +11839,6 @@ definitions:
         readOnly: true
         type: boolean
     type: object
-    x-okta-operations:
-      - alias: hideEndUserFooter
-        operationId: hideOktaUIFooter
-      - alias: showEndUserFooter
-        operationId: showOktaUIFooter
     x-okta-tags:
       - Org
   OrgSetting:
@@ -11927,22 +11904,16 @@ definitions:
     x-okta-operations:
       - alias: partialUpdate
         arguments:
-          - dest: authenticatorId
-            src: id
+          - dest: orgSetting
+            self: true
         operationId: partialUpdateOrgSetting
-      - alias: contactTypes
+      - alias: getContactTypes
         operationId: getOrgContactTypes
-      - alias: contactUser
-        arguments:
-          - dest: contactType
-            src: type
+      - alias: getOrgContactUser
         operationId: getOrgContactUser
       - alias: updateContactUser
-        arguments:
-          - dest: userId
-            src: id
         operationId: updateOrgContactUser
-      - alias: supportSettings
+      - alias: getSupportSettings
         operationId: getOrgOktaSupportSettings
       - alias: grantSupport
         operationId: grantOktaSupport
@@ -11950,13 +11921,13 @@ definitions:
         operationId: extendOktaSupport
       - alias: revokeSupport
         operationId: revokeOktaSupport
-      - alias: communicationSettings
+      - alias: getCommunicationSettings
         operationId: getOktaCommunicationSettings
       - alias: optOutCommunications
         operationId: optOutUsersFromOktaCommunicationEmails
       - alias: optInCommunications
         operationId: optInUsersToOktaCommunicationEmails
-      - alias: orgPreferences
+      - alias: getOrgPreferences
         operationId: getOrgPreferences
       - alias: showFooter
         operationId: showOktaUIFooter
@@ -14228,6 +14199,7 @@ definitions:
       userId:
         type: string
     type: object
+    x-okta-parent: '#/definitions/OrgContactUser'
     x-okta-tags:
       - Org
   UserIdentifierConditionEvaluatorPattern:

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -11795,6 +11795,12 @@ definitions:
       userId:
         type: string
     type: object
+    x-okta-operations:
+      - alias: updateContactUser
+        arguments:
+          - dest: userId
+            src: userId
+        operationId: updateOrgContactUser
     x-okta-tags:
       - Org
   OrgOktaCommunicationSetting:
@@ -11806,6 +11812,11 @@ definitions:
         readOnly: true
         type: boolean
     type: object
+    x-okta-operations:
+      - alias: optInUsersToOktaCommunicationEmails
+        operationId: optInUsersToOktaCommunicationEmails
+      - alias: optOutUsersFromOktaCommunicationEmails
+        operationId: optOutUsersFromOktaCommunicationEmails
     x-okta-tags:
       - Org
   OrgOktaSupportSetting:
@@ -11828,6 +11839,13 @@ definitions:
         $ref: '#/definitions/OrgOktaSupportSetting'
         readOnly: true
     type: object
+    x-okta-operations:
+      - alias: extendOktaSupport
+        operationId: extendOktaSupport
+      - alias: grantOktaSupport
+        operationId: grantOktaSupport
+      - alias: revokeOktaSupport
+        operationId: revokeOktaSupport
     x-okta-tags:
       - Org
   OrgPreferences:
@@ -11839,6 +11857,11 @@ definitions:
         readOnly: true
         type: boolean
     type: object
+    x-okta-operations:
+      - alias: hideEndUserFooter
+        operationId: hideOktaUIFooter
+      - alias: showEndUserFooter
+        operationId: showOktaUIFooter
     x-okta-tags:
       - Org
   OrgSetting:
@@ -11911,28 +11934,12 @@ definitions:
         operationId: getOrgContactTypes
       - alias: getOrgContactUser
         operationId: getOrgContactUser
-      - alias: updateContactUser
-        operationId: updateOrgContactUser
       - alias: getSupportSettings
         operationId: getOrgOktaSupportSettings
-      - alias: grantSupport
-        operationId: grantOktaSupport
-      - alias: extendSupport
-        operationId: extendOktaSupport
-      - alias: revokeSupport
-        operationId: revokeOktaSupport
-      - alias: getCommunicationSettings
+      - alias: communicationSettings
         operationId: getOktaCommunicationSettings
-      - alias: optOutCommunications
-        operationId: optOutUsersFromOktaCommunicationEmails
-      - alias: optInCommunications
-        operationId: optInUsersToOktaCommunicationEmails
-      - alias: getOrgPreferences
+      - alias: orgPreferences
         operationId: getOrgPreferences
-      - alias: showFooter
-        operationId: showOktaUIFooter
-      - alias: hideFooter
-        operationId: hideOktaUIFooter
     x-okta-tags:
       - Org
   PasswordCredential:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/openapi",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Utilities to generate OpenAPI specifications for the Okta API",
   "main": "./dist/spec.json",
   "bin": {

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -10706,75 +10706,43 @@ definitions:
           - dest: orgSetting
             self: true
         operationId: updateOrgSetting
+    x-okta-operations:
       - alias: partialUpdate
         arguments:
-          - dest: orgSetting
-            self: true
+          - dest: authenticatorId
+            src: id
         operationId: partialUpdateOrgSetting
       - alias: contactTypes
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: getOrgContactTypes
       - alias: contactUser
         arguments:
-          - dest: orgSetting
-            self: true
+          - dest: contactType
+            src: type
         operationId: getOrgContactUser
       - alias: updateContactUser
         arguments:
-          - dest: orgSetting
-            self: true
+          - dest: userId
+            src: id
         operationId: updateOrgContactUser
       - alias: supportSettings
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: getOrgOktaSupportSettings
       - alias: grantSupport
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: grantOktaSupport
       - alias: extendSupport
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: extendOktaSupport
       - alias: revokeSupport
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: revokeOktaSupport
       - alias: communicationSettings
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: getOktaCommunicationSettings
       - alias: optOutCommunications
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: optOutUsersFromOktaCommunicationEmails
       - alias: optInCommunications
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: optInUsersToOktaCommunicationEmails
       - alias: orgPreferences
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: getOrgPreferences
       - alias: showFooter
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: showOktaUIFooter
       - alias: hideFooter
-        arguments:
-          - dest: orgSetting
-            self: true
         operationId: hideOktaUIFooter
     x-okta-tags:
       - Org

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -10604,6 +10604,11 @@ definitions:
         type: boolean
         readOnly: true
     type: object
+    x-okta-operations:
+      - alias: optInUsersToOktaCommunicationEmails
+        operationId: optInUsersToOktaCommunicationEmails
+      - alias: optOutUsersFromOktaCommunicationEmails
+        operationId: optOutUsersFromOktaCommunicationEmails
     x-okta-tags:
       - Org
   OrgContactTypeObj:
@@ -10633,6 +10638,12 @@ definitions:
       userId:
         type: string
     type: object
+    x-okta-operations:
+      - alias: updateContactUser
+        arguments:
+          - dest: userId
+            src: userId
+        operationId: updateOrgContactUser
     x-okta-tags:
       - Org
   OrgSetting:
@@ -10705,28 +10716,12 @@ definitions:
         operationId: getOrgContactTypes
       - alias: getOrgContactUser
         operationId: getOrgContactUser
-      - alias: updateContactUser
-        operationId: updateOrgContactUser
       - alias: getSupportSettings
         operationId: getOrgOktaSupportSettings
-      - alias: grantSupport
-        operationId: grantOktaSupport
-      - alias: extendSupport
-        operationId: extendOktaSupport
-      - alias: revokeSupport
-        operationId: revokeOktaSupport
-      - alias: getCommunicationSettings
+      - alias: communicationSettings
         operationId: getOktaCommunicationSettings
-      - alias: optOutCommunications
-        operationId: optOutUsersFromOktaCommunicationEmails
-      - alias: optInCommunications
-        operationId: optInUsersToOktaCommunicationEmails
-      - alias: getOrgPreferences
+      - alias: orgPreferences
         operationId: getOrgPreferences
-      - alias: showFooter
-        operationId: showOktaUIFooter
-      - alias: hideFooter
-        operationId: hideOktaUIFooter
     x-okta-tags:
       - Org
   OrgOktaSupportSetting:
@@ -10749,6 +10744,13 @@ definitions:
         $ref: '#/definitions/OrgOktaSupportSetting'
         readOnly: true
     type: object
+    x-okta-operations:
+      - alias: extendOktaSupport
+        operationId: extendOktaSupport
+      - alias: grantOktaSupport
+        operationId: grantOktaSupport
+      - alias: revokeOktaSupport
+        operationId: revokeOktaSupport
     x-okta-tags:
       - Org
   OrgPreferences:
@@ -10760,6 +10762,11 @@ definitions:
         type: boolean
         readOnly: true
     type: object
+    x-okta-operations:
+      - alias: hideEndUserFooter
+        operationId: hideOktaUIFooter
+      - alias: showEndUserFooter
+        operationId: showOktaUIFooter
     x-okta-tags:
       - Org
   UserIdString:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -10604,11 +10604,6 @@ definitions:
         type: boolean
         readOnly: true
     type: object
-    x-okta-operations:
-      - alias: optInUsersToOktaCommunicationEmails
-        operationId: optInUsersToOktaCommunicationEmails
-      - alias: optOutUsersFromOktaCommunicationEmails
-        operationId: optOutUsersFromOktaCommunicationEmails
     x-okta-tags:
       - Org
   OrgContactTypeObj:
@@ -10638,12 +10633,6 @@ definitions:
       userId:
         type: string
     type: object
-    x-okta-operations:
-      - alias: updateContactUser
-        arguments:
-          - dest: userId
-            src: userId
-        operationId: updateOrgContactUser
     x-okta-tags:
       - Org
   OrgSetting:
@@ -10709,22 +10698,16 @@ definitions:
     x-okta-operations:
       - alias: partialUpdate
         arguments:
-          - dest: authenticatorId
-            src: id
+          - dest: orgSetting
+            self: true
         operationId: partialUpdateOrgSetting
-      - alias: contactTypes
+      - alias: getContactTypes
         operationId: getOrgContactTypes
-      - alias: contactUser
-        arguments:
-          - dest: contactType
-            src: type
+      - alias: getOrgContactUser
         operationId: getOrgContactUser
       - alias: updateContactUser
-        arguments:
-          - dest: userId
-            src: id
         operationId: updateOrgContactUser
-      - alias: supportSettings
+      - alias: getSupportSettings
         operationId: getOrgOktaSupportSettings
       - alias: grantSupport
         operationId: grantOktaSupport
@@ -10732,13 +10715,13 @@ definitions:
         operationId: extendOktaSupport
       - alias: revokeSupport
         operationId: revokeOktaSupport
-      - alias: communicationSettings
+      - alias: getCommunicationSettings
         operationId: getOktaCommunicationSettings
       - alias: optOutCommunications
         operationId: optOutUsersFromOktaCommunicationEmails
       - alias: optInCommunications
         operationId: optInUsersToOktaCommunicationEmails
-      - alias: orgPreferences
+      - alias: getOrgPreferences
         operationId: getOrgPreferences
       - alias: showFooter
         operationId: showOktaUIFooter
@@ -10766,13 +10749,6 @@ definitions:
         $ref: '#/definitions/OrgOktaSupportSetting'
         readOnly: true
     type: object
-    x-okta-operations:
-      - alias: extendOktaSupport
-        operationId: extendOktaSupport
-      - alias: grantOktaSupport
-        operationId: grantOktaSupport
-      - alias: revokeOktaSupport
-        operationId: revokeOktaSupport
     x-okta-tags:
       - Org
   OrgPreferences:
@@ -10784,11 +10760,6 @@ definitions:
         type: boolean
         readOnly: true
     type: object
-    x-okta-operations:
-      - alias: hideEndUserFooter
-        operationId: hideOktaUIFooter
-      - alias: showEndUserFooter
-        operationId: showOktaUIFooter
     x-okta-tags:
       - Org
   UserIdString:
@@ -10796,6 +10767,7 @@ definitions:
       userId:
         type: string
     type: object
+    x-okta-parent: '#/definitions/OrgContactUser'
     x-okta-tags:
       - Org
   UserSchema:


### PR DESCRIPTION
This update add the OrgSettings operations.  This is to address Java's broken IT's due to the way they were built.

There still may be an issue with duplicated model operations, and if that is the case, we should remove all duplicates from outside of `OrgSettings` model.

This is built as a patch release 2.8.1 and should be merged into the 2.8 branch.  Once released, we need to port these changes into the 2.9/master branch as well.

Edit:  Were removing duplicates from inside of `OrgSettings` for backwards compat issues