### PR TITLE
Brands API: fixes for Java SDK

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -3601,7 +3601,7 @@
             "name": "theme",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/Theme"
+              "$ref": "#/definitions/ThemeSettings"
             }
           }
         ],
@@ -22006,10 +22006,6 @@
             {
               "dest": "themeId",
               "src": "id"
-            },
-            {
-              "dest": "theme",
-              "self": true
             }
           ],
           "operationId": "updateBrandTheme"
@@ -22077,6 +22073,38 @@
           "operationId": "deleteBrandThemeBackgroundImage"
         }
       ],
+      "x-okta-tags": [
+        "Brand"
+      ]
+    },
+    "ThemeSettings": {
+      "properties": {
+        "emailTemplateTouchPointVariant": {
+          "$ref": "#/definitions/EmailTemplateTouchPointVariant"
+        },
+        "endUserDashboardTouchPointVariant": {
+          "$ref": "#/definitions/EndUserDashboardTouchPointVariant"
+        },
+        "errorPageTouchPointVariant": {
+          "$ref": "#/definitions/ErrorPageTouchPointVariant"
+        },
+        "primaryColorContrastHex": {
+          "type": "string"
+        },
+        "primaryColorHex": {
+          "type": "string"
+        },
+        "secondaryColorContrastHex": {
+          "type": "string"
+        },
+        "secondaryColorHex": {
+          "type": "string"
+        },
+        "signInPageTouchPointVariant": {
+          "$ref": "#/definitions/SignInPageTouchPointVariant"
+        }
+      },
+      "x-okta-parent": "#/definitions/Theme",
       "x-okta-tags": [
         "Brand"
       ]

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -3518,7 +3518,7 @@
             "description": "Success",
             "schema": {
               "items": {
-                "$ref": "#/definitions/Theme"
+                "$ref": "#/definitions/ThemeResponse"
               },
               "type": "array"
             }
@@ -3563,7 +3563,7 @@
           "200": {
             "description": "Success",
             "schema": {
-              "$ref": "#/definitions/Theme"
+              "$ref": "#/definitions/ThemeResponse"
             }
           }
         },
@@ -3601,7 +3601,7 @@
             "name": "theme",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/ThemeSettings"
+              "$ref": "#/definitions/Theme"
             }
           }
         ],
@@ -3612,7 +3612,7 @@
           "200": {
             "description": "Success",
             "schema": {
-              "$ref": "#/definitions/Theme"
+              "$ref": "#/definitions/ThemeResponse"
             }
           },
           "400": {
@@ -21961,6 +21961,84 @@
         "errorPageTouchPointVariant": {
           "$ref": "#/definitions/ErrorPageTouchPointVariant"
         },
+        "primaryColorContrastHex": {
+          "type": "string"
+        },
+        "primaryColorHex": {
+          "type": "string"
+        },
+        "secondaryColorContrastHex": {
+          "type": "string"
+        },
+        "secondaryColorHex": {
+          "type": "string"
+        },
+        "signInPageTouchPointVariant": {
+          "$ref": "#/definitions/SignInPageTouchPointVariant"
+        }
+      },
+      "x-okta-crud": [
+        {
+          "alias": "read",
+          "operationId": "getBrandTheme"
+        },
+        {
+          "alias": "update",
+          "operationId": "updateBrandTheme"
+        }
+      ],
+      "x-okta-operations": [
+        {
+          "alias": "uploadBrandThemeLogo",
+          "operationId": "uploadBrandThemeLogo"
+        },
+        {
+          "alias": "deleteBrandThemeLogo",
+          "operationId": "deleteBrandThemeLogo"
+        },
+        {
+          "alias": "updateBrandThemeFavicon",
+          "operationId": "uploadBrandThemeFavicon"
+        },
+        {
+          "alias": "deleteBrandThemeFavicon",
+          "operationId": "deleteBrandThemeFavicon"
+        },
+        {
+          "alias": "updateBrandThemeBackgroundImage",
+          "operationId": "uploadBrandThemeBackgroundImage"
+        },
+        {
+          "alias": "deleteBrandThemeBackgroundImage",
+          "operationId": "deleteBrandThemeBackgroundImage"
+        }
+      ],
+      "x-okta-tags": [
+        "Brand"
+      ]
+    },
+    "ThemeResponse": {
+      "properties": {
+        "_links": {
+          "additionalProperties": {
+            "type": "object"
+          },
+          "readOnly": true,
+          "type": "object"
+        },
+        "backgroundImage": {
+          "readOnly": true,
+          "type": "string"
+        },
+        "emailTemplateTouchPointVariant": {
+          "$ref": "#/definitions/EmailTemplateTouchPointVariant"
+        },
+        "endUserDashboardTouchPointVariant": {
+          "$ref": "#/definitions/EndUserDashboardTouchPointVariant"
+        },
+        "errorPageTouchPointVariant": {
+          "$ref": "#/definitions/ErrorPageTouchPointVariant"
+        },
         "favicon": {
           "readOnly": true,
           "type": "string"
@@ -21989,122 +22067,6 @@
           "$ref": "#/definitions/SignInPageTouchPointVariant"
         }
       },
-      "x-okta-crud": [
-        {
-          "alias": "read",
-          "arguments": [
-            {
-              "dest": "themeId",
-              "src": "id"
-            }
-          ],
-          "operationId": "getBrandTheme"
-        },
-        {
-          "alias": "update",
-          "arguments": [
-            {
-              "dest": "themeId",
-              "src": "id"
-            }
-          ],
-          "operationId": "updateBrandTheme"
-        }
-      ],
-      "x-okta-operations": [
-        {
-          "alias": "uploadBrandThemeLogo",
-          "arguments": [
-            {
-              "dest": "themeId",
-              "src": "id"
-            }
-          ],
-          "operationId": "uploadBrandThemeLogo"
-        },
-        {
-          "alias": "deleteBrandThemeLogo",
-          "arguments": [
-            {
-              "dest": "themeId",
-              "src": "id"
-            }
-          ],
-          "operationId": "deleteBrandThemeLogo"
-        },
-        {
-          "alias": "updateBrandThemeFavicon",
-          "arguments": [
-            {
-              "dest": "themeId",
-              "src": "id"
-            }
-          ],
-          "operationId": "uploadBrandThemeFavicon"
-        },
-        {
-          "alias": "deleteBrandThemeFavicon",
-          "arguments": [
-            {
-              "dest": "themeId",
-              "src": "id"
-            }
-          ],
-          "operationId": "deleteBrandThemeFavicon"
-        },
-        {
-          "alias": "updateBrandThemeBackgroundImage",
-          "arguments": [
-            {
-              "dest": "themeId",
-              "src": "id"
-            }
-          ],
-          "operationId": "uploadBrandThemeBackgroundImage"
-        },
-        {
-          "alias": "deleteBrandThemeBackgroundImage",
-          "arguments": [
-            {
-              "dest": "themeId",
-              "src": "id"
-            }
-          ],
-          "operationId": "deleteBrandThemeBackgroundImage"
-        }
-      ],
-      "x-okta-tags": [
-        "Brand"
-      ]
-    },
-    "ThemeSettings": {
-      "properties": {
-        "emailTemplateTouchPointVariant": {
-          "$ref": "#/definitions/EmailTemplateTouchPointVariant"
-        },
-        "endUserDashboardTouchPointVariant": {
-          "$ref": "#/definitions/EndUserDashboardTouchPointVariant"
-        },
-        "errorPageTouchPointVariant": {
-          "$ref": "#/definitions/ErrorPageTouchPointVariant"
-        },
-        "primaryColorContrastHex": {
-          "type": "string"
-        },
-        "primaryColorHex": {
-          "type": "string"
-        },
-        "secondaryColorContrastHex": {
-          "type": "string"
-        },
-        "secondaryColorHex": {
-          "type": "string"
-        },
-        "signInPageTouchPointVariant": {
-          "$ref": "#/definitions/SignInPageTouchPointVariant"
-        }
-      },
-      "x-okta-parent": "#/definitions/Theme",
       "x-okta-tags": [
         "Brand"
       ]

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -2239,7 +2239,7 @@ paths:
           description: Success
           schema:
             items:
-              $ref: '#/definitions/Theme'
+              $ref: '#/definitions/ThemeResponse'
             type: array
       security:
         - api_token: []
@@ -2267,7 +2267,7 @@ paths:
         '200':
           description: Success
           schema:
-            $ref: '#/definitions/Theme'
+            $ref: '#/definitions/ThemeResponse'
       security:
         - api_token: []
       summary: Get a theme for a brand
@@ -2291,14 +2291,14 @@ paths:
           name: theme
           required: true
           schema:
-            $ref: '#/definitions/ThemeSettings'
+            $ref: '#/definitions/Theme'
       produces:
         - application/json
       responses:
         '200':
           description: Success
           schema:
-            $ref: '#/definitions/Theme'
+            $ref: '#/definitions/ThemeResponse'
         '400':
           description: Bad Request
         '404':
@@ -14102,6 +14102,52 @@ definitions:
         $ref: '#/definitions/EndUserDashboardTouchPointVariant'
       errorPageTouchPointVariant:
         $ref: '#/definitions/ErrorPageTouchPointVariant'
+      primaryColorContrastHex:
+        type: string
+      primaryColorHex:
+        type: string
+      secondaryColorContrastHex:
+        type: string
+      secondaryColorHex:
+        type: string
+      signInPageTouchPointVariant:
+        $ref: '#/definitions/SignInPageTouchPointVariant'
+    x-okta-crud:
+      - alias: read
+        operationId: getBrandTheme
+      - alias: update
+        operationId: updateBrandTheme
+    x-okta-operations:
+      - alias: uploadBrandThemeLogo
+        operationId: uploadBrandThemeLogo
+      - alias: deleteBrandThemeLogo
+        operationId: deleteBrandThemeLogo
+      - alias: updateBrandThemeFavicon
+        operationId: uploadBrandThemeFavicon
+      - alias: deleteBrandThemeFavicon
+        operationId: deleteBrandThemeFavicon
+      - alias: updateBrandThemeBackgroundImage
+        operationId: uploadBrandThemeBackgroundImage
+      - alias: deleteBrandThemeBackgroundImage
+        operationId: deleteBrandThemeBackgroundImage
+    x-okta-tags:
+      - Brand
+  ThemeResponse:
+    properties:
+      _links:
+        additionalProperties:
+          type: object
+        readOnly: true
+        type: object
+      backgroundImage:
+        readOnly: true
+        type: string
+      emailTemplateTouchPointVariant:
+        $ref: '#/definitions/EmailTemplateTouchPointVariant'
+      endUserDashboardTouchPointVariant:
+        $ref: '#/definitions/EndUserDashboardTouchPointVariant'
+      errorPageTouchPointVariant:
+        $ref: '#/definitions/ErrorPageTouchPointVariant'
       favicon:
         readOnly: true
         type: string
@@ -14121,69 +14167,6 @@ definitions:
         type: string
       signInPageTouchPointVariant:
         $ref: '#/definitions/SignInPageTouchPointVariant'
-    x-okta-crud:
-      - alias: read
-        arguments:
-          - dest: themeId
-            src: id
-        operationId: getBrandTheme
-      - alias: update
-        arguments:
-          - dest: themeId
-            src: id
-        operationId: updateBrandTheme
-    x-okta-operations:
-      - alias: uploadBrandThemeLogo
-        arguments:
-          - dest: themeId
-            src: id
-        operationId: uploadBrandThemeLogo
-      - alias: deleteBrandThemeLogo
-        arguments:
-          - dest: themeId
-            src: id
-        operationId: deleteBrandThemeLogo
-      - alias: updateBrandThemeFavicon
-        arguments:
-          - dest: themeId
-            src: id
-        operationId: uploadBrandThemeFavicon
-      - alias: deleteBrandThemeFavicon
-        arguments:
-          - dest: themeId
-            src: id
-        operationId: deleteBrandThemeFavicon
-      - alias: updateBrandThemeBackgroundImage
-        arguments:
-          - dest: themeId
-            src: id
-        operationId: uploadBrandThemeBackgroundImage
-      - alias: deleteBrandThemeBackgroundImage
-        arguments:
-          - dest: themeId
-            src: id
-        operationId: deleteBrandThemeBackgroundImage
-    x-okta-tags:
-      - Brand
-  ThemeSettings:
-    properties:
-      emailTemplateTouchPointVariant:
-        $ref: '#/definitions/EmailTemplateTouchPointVariant'
-      endUserDashboardTouchPointVariant:
-        $ref: '#/definitions/EndUserDashboardTouchPointVariant'
-      errorPageTouchPointVariant:
-        $ref: '#/definitions/ErrorPageTouchPointVariant'
-      primaryColorContrastHex:
-        type: string
-      primaryColorHex:
-        type: string
-      secondaryColorContrastHex:
-        type: string
-      secondaryColorHex:
-        type: string
-      signInPageTouchPointVariant:
-        $ref: '#/definitions/SignInPageTouchPointVariant'
-    x-okta-parent: '#/definitions/Theme'
     x-okta-tags:
       - Brand
   ThreatInsightConfiguration:

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -2291,7 +2291,7 @@ paths:
           name: theme
           required: true
           schema:
-            $ref: '#/definitions/Theme'
+            $ref: '#/definitions/ThemeSettings'
       produces:
         - application/json
       responses:
@@ -14131,8 +14131,6 @@ definitions:
         arguments:
           - dest: themeId
             src: id
-          - dest: theme
-            self: true
         operationId: updateBrandTheme
     x-okta-operations:
       - alias: uploadBrandThemeLogo
@@ -14165,6 +14163,27 @@ definitions:
           - dest: themeId
             src: id
         operationId: deleteBrandThemeBackgroundImage
+    x-okta-tags:
+      - Brand
+  ThemeSettings:
+    properties:
+      emailTemplateTouchPointVariant:
+        $ref: '#/definitions/EmailTemplateTouchPointVariant'
+      endUserDashboardTouchPointVariant:
+        $ref: '#/definitions/EndUserDashboardTouchPointVariant'
+      errorPageTouchPointVariant:
+        $ref: '#/definitions/ErrorPageTouchPointVariant'
+      primaryColorContrastHex:
+        type: string
+      primaryColorHex:
+        type: string
+      secondaryColorContrastHex:
+        type: string
+      secondaryColorHex:
+        type: string
+      signInPageTouchPointVariant:
+        $ref: '#/definitions/SignInPageTouchPointVariant'
+    x-okta-parent: '#/definitions/Theme'
     x-okta-tags:
       - Brand
   ThreatInsightConfiguration:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -7907,7 +7907,7 @@ paths:
           name: theme
           required: true
           schema:
-            $ref: '#/definitions/Theme'
+            $ref: '#/definitions/ThemeSettings'
       responses:
         '200':
           description: Success
@@ -15186,8 +15186,6 @@ definitions:
         arguments:
           - dest: themeId
             src: id
-          - dest: theme
-            self: true
         operationId: updateBrandTheme
     x-okta-operations:
       - alias: uploadBrandThemeLogo
@@ -15220,6 +15218,27 @@ definitions:
           - dest: themeId
             src: id
         operationId: deleteBrandThemeBackgroundImage
+    x-okta-tags:
+      - Brand
+  ThemeSettings:
+    properties:
+      emailTemplateTouchPointVariant:
+        $ref: '#/definitions/EmailTemplateTouchPointVariant'
+      endUserDashboardTouchPointVariant:
+        $ref: '#/definitions/EndUserDashboardTouchPointVariant'
+      errorPageTouchPointVariant:
+        $ref: '#/definitions/ErrorPageTouchPointVariant'
+      primaryColorContrastHex:
+        type: string
+      primaryColorHex:
+        type: string
+      secondaryColorContrastHex:
+        type: string
+      secondaryColorHex:
+        type: string
+      signInPageTouchPointVariant:
+        $ref: '#/definitions/SignInPageTouchPointVariant'
+    x-okta-parent: '#/definitions/Theme'
     x-okta-tags:
       - Brand
   SignInPageTouchPointVariant:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -7853,7 +7853,7 @@ paths:
           description: Success
           schema:
             items:
-              $ref: '#/definitions/Theme'
+              $ref: '#/definitions/ThemeResponse'
             type: array
       security:
         - api_token: []
@@ -7881,7 +7881,7 @@ paths:
         '200':
           description: Success
           schema:
-            $ref: '#/definitions/Theme'
+            $ref: '#/definitions/ThemeResponse'
       security:
         - api_token: []
       summary: Get a theme for a brand
@@ -7907,12 +7907,12 @@ paths:
           name: theme
           required: true
           schema:
-            $ref: '#/definitions/ThemeSettings'
+            $ref: '#/definitions/Theme'
       responses:
         '200':
           description: Success
           schema:
-            $ref: '#/definitions/Theme'
+            $ref: '#/definitions/ThemeResponse'
         '400':
           description: Bad Request
         '404':
@@ -15143,6 +15143,52 @@ definitions:
       - Brand
   Theme:
     properties:
+      backgroundImage:
+        type: string
+        readOnly: true
+      primaryColorHex:
+        type: string
+      primaryColorContrastHex:
+        type: string
+      secondaryColorHex:
+        type: string
+      secondaryColorContrastHex:
+        type: string
+      signInPageTouchPointVariant:
+        $ref: '#/definitions/SignInPageTouchPointVariant'
+      endUserDashboardTouchPointVariant:
+        $ref: '#/definitions/EndUserDashboardTouchPointVariant'
+      errorPageTouchPointVariant:
+        $ref: '#/definitions/ErrorPageTouchPointVariant'
+      emailTemplateTouchPointVariant:
+        $ref: '#/definitions/EmailTemplateTouchPointVariant'
+      _links:
+        additionalProperties:
+          type: object
+        readOnly: true
+        type: object
+    x-okta-crud:
+      - alias: read
+        operationId: getBrandTheme
+      - alias: update
+        operationId: updateBrandTheme
+    x-okta-operations:
+      - alias: uploadBrandThemeLogo
+        operationId: uploadBrandThemeLogo
+      - alias: deleteBrandThemeLogo
+        operationId: deleteBrandThemeLogo
+      - alias: updateBrandThemeFavicon
+        operationId: uploadBrandThemeFavicon
+      - alias: deleteBrandThemeFavicon
+        operationId: deleteBrandThemeFavicon
+      - alias: updateBrandThemeBackgroundImage
+        operationId: uploadBrandThemeBackgroundImage
+      - alias: deleteBrandThemeBackgroundImage
+        operationId: deleteBrandThemeBackgroundImage
+    x-okta-tags:
+      - Brand
+  ThemeResponse:
+    properties:
       id:
         type: string
         readOnly: true
@@ -15176,69 +15222,6 @@ definitions:
           type: object
         readOnly: true
         type: object
-    x-okta-crud:
-      - alias: read
-        arguments:
-          - dest: themeId
-            src: id
-        operationId: getBrandTheme
-      - alias: update
-        arguments:
-          - dest: themeId
-            src: id
-        operationId: updateBrandTheme
-    x-okta-operations:
-      - alias: uploadBrandThemeLogo
-        arguments:
-          - dest: themeId
-            src: id
-        operationId: uploadBrandThemeLogo
-      - alias: deleteBrandThemeLogo
-        arguments:
-          - dest: themeId
-            src: id
-        operationId: deleteBrandThemeLogo
-      - alias: updateBrandThemeFavicon
-        arguments:
-          - dest: themeId
-            src: id
-        operationId: uploadBrandThemeFavicon
-      - alias: deleteBrandThemeFavicon
-        arguments:
-          - dest: themeId
-            src: id
-        operationId: deleteBrandThemeFavicon
-      - alias: updateBrandThemeBackgroundImage
-        arguments:
-          - dest: themeId
-            src: id
-        operationId: uploadBrandThemeBackgroundImage
-      - alias: deleteBrandThemeBackgroundImage
-        arguments:
-          - dest: themeId
-            src: id
-        operationId: deleteBrandThemeBackgroundImage
-    x-okta-tags:
-      - Brand
-  ThemeSettings:
-    properties:
-      emailTemplateTouchPointVariant:
-        $ref: '#/definitions/EmailTemplateTouchPointVariant'
-      endUserDashboardTouchPointVariant:
-        $ref: '#/definitions/EndUserDashboardTouchPointVariant'
-      errorPageTouchPointVariant:
-        $ref: '#/definitions/ErrorPageTouchPointVariant'
-      primaryColorContrastHex:
-        type: string
-      primaryColorHex:
-        type: string
-      secondaryColorContrastHex:
-        type: string
-      secondaryColorHex:
-        type: string
-      signInPageTouchPointVariant:
-        $ref: '#/definitions/SignInPageTouchPointVariant'
-    x-okta-parent: '#/definitions/Theme'
     x-okta-tags:
       - Brand
   SignInPageTouchPointVariant:


### PR DESCRIPTION
The `updateBrandTheme ` method works incorrectly.

According to [docs](https://developer.okta.com/docs/reference/api/brands/#update-theme),  only the next fields could be presented in a request body:
```
primaryColorHex
primaryColorContrastHex
secondaryColorHex
secondaryColorContrastHex
signInPageTouchPointVariant
endUserDashboardTouchPointVariant
errorPageTouchPointVariant
emailTemplateTouchPointVariant
```
So a new `ThemeSettings` object is created.
 
[Related Sluck thread](https://okta.slack.com/archives/G7VT7GL0J/p1635864440190900)