### PR TITLE
Added missing fields for Apple IdP

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -13,7 +13,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "2.9.1"
+    "version": "2.9.2"
   },
   "externalDocs": {
     "description": "Find more info here",
@@ -15560,6 +15560,7 @@
           "type": "boolean"
         }
       },
+      "x-okta-parent": "#/definitions/DevicePolicyRuleCondition",
       "x-okta-tags": [
         "Policy"
       ]
@@ -17232,6 +17233,12 @@
     "IdentityProviderCredentialsSigning": {
       "properties": {
         "kid": {
+          "type": "string"
+        },
+        "privateKey": {
+          "type": "string"
+        },
+        "teamId": {
           "type": "string"
         }
       },

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -25,7 +25,7 @@ info:
   license:
     name: Apache-2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
-  version: 2.9.1
+  version: 2.9.2
 externalDocs:
   description: Find more info here
   url: 'https://developer.okta.com/docs/api/getting_started/design_principles.html'
@@ -9896,6 +9896,7 @@ definitions:
         type: boolean
       registered:
         type: boolean
+    x-okta-parent: '#/definitions/DevicePolicyRuleCondition'
     x-okta-tags:
       - Policy
   DevicePolicyRuleCondition:
@@ -10968,6 +10969,10 @@ definitions:
   IdentityProviderCredentialsSigning:
     properties:
       kid:
+        type: string
+      privateKey:
+        type: string
+      teamId:
         type: string
     type: object
     x-okta-tags:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/openapi",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "Utilities to generate OpenAPI specifications for the Okta API",
   "main": "./dist/spec.json",
   "bin": {

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -10504,6 +10504,10 @@ definitions:
     properties:
       kid:
         type: string
+      privateKey:
+        type: string
+      teamId:
+        type: string
     type: object
     x-okta-tags:
       - IdentityProvider
@@ -10793,6 +10797,7 @@ definitions:
         type: boolean
       managed:
         type: boolean
+    x-okta-parent: '#/definitions/DevicePolicyRuleCondition'
     x-okta-tags:
       - Policy
   AccessPolicyRuleActions:


### PR DESCRIPTION
https://developer.okta.com/docs/reference/api/idps/#add-apple-identity-provider

Raleated to https://github.com/okta/terraform-provider-okta/issues/841