### PR TITLE
Added missing fields for Apple IdP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Running changelog of releases since `2.2.3`
 
 ## 2.9.1
 
+### Bug fixes
+ - Added `sharedSecret` attribute to `AuthenticatorProviderConfiguration` 
+ - `Authenticator`'s properties should not inherit from `Authenticator`
+
 ### Bug Fixes:
 
 - [#102](https://github.com/okta/okta-management-openapi-spec/pull/102) `AuthenticatorProvider`, `AuthenticatorProviderConfiguration`, `AuthenticatorProviderConfigurationUserNamePlate` no longer inherit from `Authenticator`

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -17234,6 +17234,12 @@
       "properties": {
         "kid": {
           "type": "string"
+        },
+        "privateKey": {
+          "type": "string"
+        },
+        "teamId": {
+          "type": "string"
         }
       },
       "type": "object",

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -10970,6 +10970,10 @@ definitions:
     properties:
       kid:
         type: string
+      privateKey:
+        type: string
+      teamId:
+        type: string
     type: object
     x-okta-tags:
       - IdentityProvider

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -10504,6 +10504,10 @@ definitions:
     properties:
       kid:
         type: string
+      privateKey:
+        type: string
+      teamId:
+        type: string
     type: object
     x-okta-tags:
       - IdentityProvider


### PR DESCRIPTION
https://developer.okta.com/docs/reference/api/idps/#add-apple-identity-provider

Raleated to https://github.com/okta/terraform-provider-okta/issues/841