### PR TITLE
Adds missing policy rule action for IDPs

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -13,7 +13,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "2.10.0"
+    "version": "2.11.0"
   },
   "externalDocs": {
     "description": "Find more info here",
@@ -18138,6 +18138,35 @@
         "Policy"
       ]
     },
+    "IdpPolicyRuleAction": {
+      "properties": {
+        "providers": {
+          "items": {
+            "$ref": "#/definitions/IdpPolicyRuleActionProvider"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "x-okta-tags": [
+        "Policy"
+      ]
+    },
+    "IdpPolicyRuleActionProvider": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-okta-tags": [
+        "Policy"
+      ]
+    },
     "ImageUploadResponse": {
       "properties": {
         "url": {
@@ -21511,6 +21540,9 @@
       "properties": {
         "enroll": {
           "$ref": "#/definitions/PolicyRuleActionsEnroll"
+        },
+        "idp": {
+          "$ref": "#/definitions/IdpPolicyRuleAction"
         },
         "passwordChange": {
           "$ref": "#/definitions/PasswordPolicyRuleAction"

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -25,7 +25,7 @@ info:
   license:
     name: Apache-2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
-  version: 2.10.0
+  version: 2.11.0
 externalDocs:
   description: Find more info here
   url: 'https://developer.okta.com/docs/api/getting_started/design_principles.html'
@@ -11572,6 +11572,25 @@ definitions:
     type: object
     x-okta-tags:
       - Policy
+  IdpPolicyRuleAction:
+    properties:
+      providers:
+        items:
+          $ref: '#/definitions/IdpPolicyRuleActionProvider'
+        type: array
+    type: object
+    x-okta-tags:
+      - Policy
+  IdpPolicyRuleActionProvider:
+    properties:
+      id:
+        readOnly: true
+        type: string
+      type:
+        type: string
+    type: object
+    x-okta-tags:
+      - Policy
   ImageUploadResponse:
     properties:
       url:
@@ -13814,6 +13833,8 @@ definitions:
     properties:
       enroll:
         $ref: '#/definitions/PolicyRuleActionsEnroll'
+      idp:
+        $ref: '#/definitions/IdpPolicyRuleAction'
       passwordChange:
         $ref: '#/definitions/PasswordPolicyRuleAction'
       selfServicePasswordReset:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -11470,6 +11470,24 @@ definitions:
     type: object
     x-okta-tags:
       - Policy
+  IdpPolicyRuleAction:
+    properties:
+      providers:
+        items:
+          $ref: '#/definitions/IdpPolicyRuleActionProvider'
+        type: array
+    type: object
+    x-okta-tags:
+      - Policy
+  IdpPolicyRuleActionProvider:
+    properties:
+      id:
+        type: string
+      type:
+        type: string
+    type: object
+    x-okta-tags:
+      - Policy
   ProfileEnrollmentPolicyRuleActions:
     properties:
       profileEnrollment:
@@ -14172,6 +14190,8 @@ definitions:
         $ref: '#/definitions/PasswordPolicyRuleAction'
       selfServiceUnlock:
         $ref: '#/definitions/PasswordPolicyRuleAction'
+      idp:
+        $ref: '#/definitions/IdpPolicyRuleAction'
     type: object
     x-okta-tags:
       - Policy


### PR DESCRIPTION
We are missing the IDP policy rule action model. This adds a IdpPolicyRuleAction and its providers array of elements IdpPolicyRuleAction

https://developer.okta.com/docs/reference/api/policy/#policy-action-object
https://github.com/okta/okta-sdk-golang/issues/279
https://github.com/okta/okta-sdk-golang/pull/280