### PR TITLE
Include Email Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,39 @@
 # Changelog
 Running changelog of releases since `2.2.3`
 
+## 2.11.0
+### Additions
+ - New Paths:
+    - `GET /api/v1/brands/{brandId}/templates/email`
+        - operation added: `listEmailTemplates`
+    - `GET /api/v1/brands/{brandId}/templates/email/{templateName}`
+        - operation added: `getEmailTemplate`
+    - `DELETE & GET & POST /api/v1/brands/{brandId}/templates/email/{templateName}/customizations`
+        - operations added: `deleteEmailTemplateCustomizations`, `listEmailTemplateCustomizations`, `createEmailTemplateCustomization`
+    - `DELETE & GET & PUT /api/v1/brands/{brandId}/templates/email/{templateName}/customizations/{customizationId}`
+        - operations added: `deleteEmailTemplateCustomization`, `getEmailTemplateCustomization`, `updateEmailTemplateCustomization`
+    - `GET /api/v1/brands/{brandId}/templates/email/{templateName}/customizations/{customizationId}/preview`
+        - operation added: `getEmailTemplateCustomizationPreview`
+    - `GET /api/v1/brands/{brandId}/templates/email/{templateName}/default-content`
+        - operation added: `getEmailTemplateDefaultContent`
+    - `GET /api/v1/brands/{brandId}/templates/email/{templateName}/default-content/preview`
+        - operation added: `getEmailTemplateDefaultContentPreview`
+    - `POST /api/v1/brands/{brandId}/templates/email/{templateName}/test`
+        - operation added: `sendTestEmail`
+ - Models Added:
+    - `EmailTemplate`
+    - `EmailTemplateCustomization`
+    - `EmailTemplateCustomizationRequest`
+    - `EmailTemplateContent`
+    - `EmailTemplateTestRequest`
+
+
+## 2.10.0
+
 ## 2.9.1
 
 ### Bug fixes
- - Added `sharedSecret` attribute to `AuthenticatorProviderConfiguration` 
+ - Added `sharedSecret` attribute to `AuthenticatorProviderConfiguration`
  - `Authenticator`'s properties should not inherit from `Authenticator`
 
 ### Bug Fixes:

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -4057,7 +4057,7 @@
             "description": "Success",
             "schema": {
               "items": {
-                "$ref": "#/definitions/EmailTemplateCustomizationRequest"
+                "$ref": "#/definitions/EmailTemplateCustomization"
               },
               "type": "array"
             }

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -4420,7 +4420,7 @@
         "consumes": [
           "application/json"
         ],
-        "description": "Send a test email to the current users primary and secondary email addresses. The email content is selected based on the following priority:\n  An email customization specifically for the users locale.\n  The default language of email customizations.\n  The email templates default content.",
+        "description": "Send a test email to the current users primary and secondary email addresses. The email content is selected based on the following priority: An email customization specifically for the users locale. The default language of email customizations. The email templates default content.",
         "operationId": "sendTestEmail",
         "parameters": [
           {
@@ -17271,7 +17271,7 @@
           "type": "string"
         },
         "isDefault": {
-          "format": "boolean"
+          "type": "boolean"
         },
         "language": {
           "description": "unique under each email template",
@@ -17296,7 +17296,7 @@
           "type": "string"
         },
         "isDefault": {
-          "format": "boolean"
+          "type": "boolean"
         },
         "language": {
           "description": "unique under each email template",

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -3893,6 +3893,579 @@
         ]
       }
     },
+    "/api/v1/brands/{brandId}/templates/email": {
+      "get": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "List email templates in your organization with pagination.",
+        "operationId": "listEmailTemplates",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "brandId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Specifies the pagination cursor for the next page of email templates.",
+            "in": "query",
+            "name": "after",
+            "type": "string"
+          },
+          {
+            "default": 20,
+            "description": "Specifies the number of results returned (maximum 200)",
+            "format": "int32",
+            "in": "query",
+            "name": "limit",
+            "type": "integer"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "items": {
+                "$ref": "#/definitions/EmailTemplate"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "security": [
+          {
+            "api_token": []
+          }
+        ],
+        "summary": "List Email Templates",
+        "tags": [
+          "Brand"
+        ]
+      }
+    },
+    "/api/v1/brands/{brandId}/templates/email/{templateName}": {
+      "get": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Fetch an email template by templateName",
+        "operationId": "getEmailTemplate",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "brandId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "templateName",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/EmailTemplate"
+            }
+          }
+        },
+        "security": [
+          {
+            "api_token": []
+          }
+        ],
+        "summary": "Get Email Template",
+        "tags": [
+          "Brand"
+        ]
+      }
+    },
+    "/api/v1/brands/{brandId}/templates/email/{templateName}/customizations": {
+      "delete": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Delete all customizations for an email template. Also known as “Reset to Default”.",
+        "operationId": "deleteEmailTemplateCustomizations",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "brandId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "templateName",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "api_token": []
+          }
+        ],
+        "summary": "Delete Email Template Customization",
+        "tags": [
+          "Brand"
+        ]
+      },
+      "get": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "List all email customizations for an email template",
+        "operationId": "listEmailTemplateCustomizations",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "brandId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "templateName",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "items": {
+                "$ref": "#/definitions/EmailTemplateCustomizationRequest"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "security": [
+          {
+            "api_token": []
+          }
+        ],
+        "summary": "List Email Template Customization",
+        "tags": [
+          "Brand"
+        ]
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Create an email customization",
+        "operationId": "createEmailTemplateCustomization",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "brandId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "templateName",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "customization",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EmailTemplateCustomizationRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/EmailTemplateCustomization"
+            }
+          },
+          "409": {
+            "description": "Conflict"
+          }
+        },
+        "security": [
+          {
+            "api_token": []
+          }
+        ],
+        "summary": "Create Email Template Customization",
+        "tags": [
+          "Brand"
+        ]
+      }
+    },
+    "/api/v1/brands/{brandId}/templates/email/{templateName}/customizations/{customizationId}": {
+      "delete": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Delete an email customization",
+        "operationId": "deleteEmailTemplateCustomization",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "brandId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "templateName",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "customizationId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "409": {
+            "description": "Conflict"
+          }
+        },
+        "security": [
+          {
+            "api_token": []
+          }
+        ],
+        "summary": "Delete Email Customization",
+        "tags": [
+          "Brand"
+        ]
+      },
+      "get": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Fetch an email customization by id.",
+        "operationId": "getEmailTemplateCustomization",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "brandId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "templateName",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "customizationId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/EmailTemplateCustomization"
+            }
+          }
+        },
+        "security": [
+          {
+            "api_token": []
+          }
+        ],
+        "summary": "Get Email Template Customization",
+        "tags": [
+          "Brand"
+        ]
+      },
+      "put": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Update an email customization",
+        "operationId": "updateEmailTemplateCustomization",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "brandId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "templateName",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "customizationId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "customization",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EmailTemplateCustomizationRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/EmailTemplateCustomization"
+            }
+          },
+          "409": {
+            "description": "Conflict"
+          }
+        },
+        "security": [
+          {
+            "api_token": []
+          }
+        ],
+        "summary": "Update Email Customization",
+        "tags": [
+          "Brand"
+        ]
+      }
+    },
+    "/api/v1/brands/{brandId}/templates/email/{templateName}/customizations/{customizationId}/preview": {
+      "get": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Get a preview of an email template customization.",
+        "operationId": "getEmailTemplateCustomizationPreview",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "brandId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "templateName",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "customizationId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/EmailTemplateContent"
+            }
+          }
+        },
+        "security": [
+          {
+            "api_token": []
+          }
+        ],
+        "summary": "Get Preview Content of Email Customization",
+        "tags": [
+          "Brand"
+        ]
+      }
+    },
+    "/api/v1/brands/{brandId}/templates/email/{templateName}/default-content": {
+      "get": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Fetch the default content for an email template.",
+        "operationId": "getEmailTemplateDefaultContent",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "brandId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "templateName",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/EmailTemplateContent"
+            }
+          }
+        },
+        "security": [
+          {
+            "api_token": []
+          }
+        ],
+        "summary": "Get Default Content of Email Template",
+        "tags": [
+          "Brand"
+        ]
+      }
+    },
+    "/api/v1/brands/{brandId}/templates/email/{templateName}/default-content/preview": {
+      "get": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Fetch a preview of an email template's default content by populating velocity references with the current user's environment.",
+        "operationId": "getEmailTemplateDefaultContentPreview",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "brandId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "templateName",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/EmailTemplateContent"
+            }
+          }
+        },
+        "security": [
+          {
+            "api_token": []
+          }
+        ],
+        "summary": "Get Preview of Email Template Default Content",
+        "tags": [
+          "Brand"
+        ]
+      }
+    },
+    "/api/v1/brands/{brandId}/templates/email/{templateName}/test": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Send a test email to the current users primary and secondary email addresses. The email content is selected based on the following priority:\n  An email customization specifically for the users locale.\n  The default language of email customizations.\n  The email templates default content.",
+        "operationId": "sendTestEmail",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "brandId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "templateName",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "customization",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EmailTemplateTestRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/EmailTemplateContent"
+            }
+          }
+        },
+        "security": [
+          {
+            "api_token": []
+          }
+        ],
+        "summary": "Get Preview of Email Template Default Content",
+        "tags": [
+          "Brand"
+        ]
+      }
+    },
     "/api/v1/brands/{brandId}/themes": {
       "get": {
         "consumes": [
@@ -16578,6 +17151,173 @@
       "type": "object",
       "x-okta-tags": [
         "Policy"
+      ]
+    },
+    "EmailTemplate": {
+      "properties": {
+        "_links": {
+          "additionalProperties": {
+            "type": "object"
+          },
+          "readOnly": true,
+          "type": "object"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string"
+        }
+      },
+      "x-okta-crud": [
+        {
+          "alias": "read",
+          "operationId": "getEmailTemplate"
+        }
+      ],
+      "x-okta-operations": [
+        {
+          "alias": "getEmailTemplate",
+          "operationId": "getEmailTemplate"
+        },
+        {
+          "alias": "deleteEmailTemplateCustomizations",
+          "operationId": "deleteEmailTemplateCustomizations"
+        },
+        {
+          "alias": "listEmailTemplateCustomizations",
+          "operationId": "listEmailTemplateCustomizations"
+        },
+        {
+          "alias": "createEmailTemplateCustomization",
+          "operationId": "createEmailTemplateCustomization"
+        },
+        {
+          "alias": "deleteEmailTemplateCustomization",
+          "operationId": "deleteEmailTemplateCustomization"
+        },
+        {
+          "alias": "getEmailTemplateCustomization",
+          "operationId": "getEmailTemplateCustomization"
+        },
+        {
+          "alias": "updateEmailTemplateCustomization",
+          "operationId": "updateEmailTemplateCustomization"
+        },
+        {
+          "alias": "getEmailTemplateCustomizationPreview",
+          "operationId": "getEmailTemplateCustomizationPreview"
+        },
+        {
+          "alias": "getEmailTemplateDefaultContent",
+          "operationId": "getEmailTemplateDefaultContent"
+        },
+        {
+          "alias": "getEmailTemplateDefaultContentPreview",
+          "operationId": "getEmailTemplateDefaultContentPreview"
+        },
+        {
+          "alias": "sendTestEmail",
+          "operationId": "sendTestEmail"
+        }
+      ],
+      "x-okta-tags": [
+        "Brands"
+      ]
+    },
+    "EmailTemplateContent": {
+      "properties": {
+        "_links": {
+          "additionalProperties": {
+            "type": "object"
+          },
+          "readOnly": true,
+          "type": "object"
+        },
+        "body": {
+          "type": "string"
+        },
+        "fromAddress": {
+          "type": "string"
+        },
+        "fromName": {
+          "type": "string"
+        },
+        "subject": {
+          "type": "string"
+        }
+      },
+      "x-okta-tags": [
+        "Brands"
+      ]
+    },
+    "EmailTemplateCustomization": {
+      "properties": {
+        "_links": {
+          "additionalProperties": {
+            "type": "object"
+          },
+          "readOnly": true,
+          "type": "object"
+        },
+        "body": {
+          "type": "string"
+        },
+        "created": {
+          "format": "date-time",
+          "readOnly": true,
+          "type": "string"
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string"
+        },
+        "isDefault": {
+          "format": "boolean"
+        },
+        "language": {
+          "description": "unique under each email template",
+          "type": "string"
+        },
+        "lastUpdated": {
+          "format": "date-time",
+          "readOnly": true,
+          "type": "string"
+        },
+        "subject": {
+          "type": "string"
+        }
+      },
+      "x-okta-tags": [
+        "Brands"
+      ]
+    },
+    "EmailTemplateCustomizationRequest": {
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "isDefault": {
+          "format": "boolean"
+        },
+        "language": {
+          "description": "unique under each email template",
+          "type": "string"
+        },
+        "subject": {
+          "type": "string"
+        }
+      },
+      "x-okta-tags": [
+        "Brands"
+      ]
+    },
+    "EmailTemplateTestRequest": {
+      "properties": {
+        "customizationId": {
+          "type": "string"
+        }
+      },
+      "x-okta-tags": [
+        "Brands"
       ]
     },
     "EmailTemplateTouchPointVariant": {

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -2818,10 +2818,9 @@ paths:
       description: >-
         Send a test email to the current users primary and secondary email
         addresses. The email content is selected based on the following
-        priority:
-          An email customization specifically for the users locale.
-          The default language of email customizations.
-          The email templates default content.
+        priority: An email customization specifically for the users locale. The
+        default language of email customizations. The email templates default
+        content.
       operationId: sendTestEmail
       parameters:
         - in: path
@@ -11021,7 +11020,7 @@ definitions:
         readOnly: true
         type: string
       isDefault:
-        format: boolean
+        type: boolean
       language:
         description: unique under each email template
         type: string
@@ -11038,7 +11037,7 @@ definitions:
       body:
         type: string
       isDefault:
-        format: boolean
+        type: boolean
       language:
         description: unique under each email template
         type: string

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -2586,7 +2586,7 @@ paths:
           description: Success
           schema:
             items:
-              $ref: '#/definitions/EmailTemplateCustomizationRequest'
+              $ref: '#/definitions/EmailTemplateCustomization'
             type: array
       security:
         - api_token: []

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -2474,6 +2474,381 @@ paths:
       summary: Update Brand
       tags:
         - Brand
+  '/api/v1/brands/{brandId}/templates/email':
+    get:
+      consumes:
+        - application/json
+      description: List email templates in your organization with pagination.
+      operationId: listEmailTemplates
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - description: >-
+            Specifies the pagination cursor for the next page of email
+            templates.
+          in: query
+          name: after
+          type: string
+        - default: 20
+          description: Specifies the number of results returned (maximum 200)
+          format: int32
+          in: query
+          name: limit
+          type: integer
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success
+          schema:
+            items:
+              $ref: '#/definitions/EmailTemplate'
+            type: array
+      security:
+        - api_token: []
+      summary: List Email Templates
+      tags:
+        - Brand
+  '/api/v1/brands/{brandId}/templates/email/{templateName}':
+    get:
+      consumes:
+        - application/json
+      description: Fetch an email template by templateName
+      operationId: getEmailTemplate
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/EmailTemplate'
+      security:
+        - api_token: []
+      summary: Get Email Template
+      tags:
+        - Brand
+  '/api/v1/brands/{brandId}/templates/email/{templateName}/customizations':
+    delete:
+      consumes:
+        - application/json
+      description: >-
+        Delete all customizations for an email template. Also known as “Reset to
+        Default”.
+      operationId: deleteEmailTemplateCustomizations
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+      produces:
+        - application/json
+      responses:
+        '204':
+          description: Success
+      security:
+        - api_token: []
+      summary: Delete Email Template Customization
+      tags:
+        - Brand
+    get:
+      consumes:
+        - application/json
+      description: List all email customizations for an email template
+      operationId: listEmailTemplateCustomizations
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success
+          schema:
+            items:
+              $ref: '#/definitions/EmailTemplateCustomizationRequest'
+            type: array
+      security:
+        - api_token: []
+      summary: List Email Template Customization
+      tags:
+        - Brand
+    post:
+      consumes:
+        - application/json
+      description: Create an email customization
+      operationId: createEmailTemplateCustomization
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+        - in: body
+          name: customization
+          required: true
+          schema:
+            $ref: '#/definitions/EmailTemplateCustomizationRequest'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/EmailTemplateCustomization'
+        '409':
+          description: Conflict
+      security:
+        - api_token: []
+      summary: Create Email Template Customization
+      tags:
+        - Brand
+  '/api/v1/brands/{brandId}/templates/email/{templateName}/customizations/{customizationId}':
+    delete:
+      consumes:
+        - application/json
+      description: Delete an email customization
+      operationId: deleteEmailTemplateCustomization
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+        - in: path
+          name: customizationId
+          required: true
+          type: string
+      produces:
+        - application/json
+      responses:
+        '204':
+          description: No Content
+        '409':
+          description: Conflict
+      security:
+        - api_token: []
+      summary: Delete Email Customization
+      tags:
+        - Brand
+    get:
+      consumes:
+        - application/json
+      description: Fetch an email customization by id.
+      operationId: getEmailTemplateCustomization
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+        - in: path
+          name: customizationId
+          required: true
+          type: string
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/EmailTemplateCustomization'
+      security:
+        - api_token: []
+      summary: Get Email Template Customization
+      tags:
+        - Brand
+    put:
+      consumes:
+        - application/json
+      description: Update an email customization
+      operationId: updateEmailTemplateCustomization
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+        - in: path
+          name: customizationId
+          required: true
+          type: string
+        - in: body
+          name: customization
+          required: true
+          schema:
+            $ref: '#/definitions/EmailTemplateCustomizationRequest'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/EmailTemplateCustomization'
+        '409':
+          description: Conflict
+      security:
+        - api_token: []
+      summary: Update Email Customization
+      tags:
+        - Brand
+  '/api/v1/brands/{brandId}/templates/email/{templateName}/customizations/{customizationId}/preview':
+    get:
+      consumes:
+        - application/json
+      description: Get a preview of an email template customization.
+      operationId: getEmailTemplateCustomizationPreview
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+        - in: path
+          name: customizationId
+          required: true
+          type: string
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/EmailTemplateContent'
+      security:
+        - api_token: []
+      summary: Get Preview Content of Email Customization
+      tags:
+        - Brand
+  '/api/v1/brands/{brandId}/templates/email/{templateName}/default-content':
+    get:
+      consumes:
+        - application/json
+      description: Fetch the default content for an email template.
+      operationId: getEmailTemplateDefaultContent
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/EmailTemplateContent'
+      security:
+        - api_token: []
+      summary: Get Default Content of Email Template
+      tags:
+        - Brand
+  '/api/v1/brands/{brandId}/templates/email/{templateName}/default-content/preview':
+    get:
+      consumes:
+        - application/json
+      description: >-
+        Fetch a preview of an email template's default content by populating
+        velocity references with the current user's environment.
+      operationId: getEmailTemplateDefaultContentPreview
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/EmailTemplateContent'
+      security:
+        - api_token: []
+      summary: Get Preview of Email Template Default Content
+      tags:
+        - Brand
+  '/api/v1/brands/{brandId}/templates/email/{templateName}/test':
+    post:
+      consumes:
+        - application/json
+      description: >-
+        Send a test email to the current users primary and secondary email
+        addresses. The email content is selected based on the following
+        priority:
+          An email customization specifically for the users locale.
+          The default language of email customizations.
+          The email templates default content.
+      operationId: sendTestEmail
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+        - in: body
+          name: customization
+          required: true
+          schema:
+            $ref: '#/definitions/EmailTemplateTestRequest'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/EmailTemplateContent'
+      security:
+        - api_token: []
+      summary: Get Preview of Email Template Default Content
+      tags:
+        - Brand
   '/api/v1/brands/{brandId}/themes':
     get:
       consumes:
@@ -10574,6 +10949,109 @@ definitions:
     type: object
     x-okta-tags:
       - Policy
+  EmailTemplate:
+    properties:
+      _links:
+        additionalProperties:
+          type: object
+        readOnly: true
+        type: object
+      name:
+        readOnly: true
+        type: string
+    x-okta-crud:
+      - alias: read
+        operationId: getEmailTemplate
+    x-okta-operations:
+      - alias: getEmailTemplate
+        operationId: getEmailTemplate
+      - alias: deleteEmailTemplateCustomizations
+        operationId: deleteEmailTemplateCustomizations
+      - alias: listEmailTemplateCustomizations
+        operationId: listEmailTemplateCustomizations
+      - alias: createEmailTemplateCustomization
+        operationId: createEmailTemplateCustomization
+      - alias: deleteEmailTemplateCustomization
+        operationId: deleteEmailTemplateCustomization
+      - alias: getEmailTemplateCustomization
+        operationId: getEmailTemplateCustomization
+      - alias: updateEmailTemplateCustomization
+        operationId: updateEmailTemplateCustomization
+      - alias: getEmailTemplateCustomizationPreview
+        operationId: getEmailTemplateCustomizationPreview
+      - alias: getEmailTemplateDefaultContent
+        operationId: getEmailTemplateDefaultContent
+      - alias: getEmailTemplateDefaultContentPreview
+        operationId: getEmailTemplateDefaultContentPreview
+      - alias: sendTestEmail
+        operationId: sendTestEmail
+    x-okta-tags:
+      - Brands
+  EmailTemplateContent:
+    properties:
+      _links:
+        additionalProperties:
+          type: object
+        readOnly: true
+        type: object
+      body:
+        type: string
+      fromAddress:
+        type: string
+      fromName:
+        type: string
+      subject:
+        type: string
+    x-okta-tags:
+      - Brands
+  EmailTemplateCustomization:
+    properties:
+      _links:
+        additionalProperties:
+          type: object
+        readOnly: true
+        type: object
+      body:
+        type: string
+      created:
+        format: date-time
+        readOnly: true
+        type: string
+      id:
+        readOnly: true
+        type: string
+      isDefault:
+        format: boolean
+      language:
+        description: unique under each email template
+        type: string
+      lastUpdated:
+        format: date-time
+        readOnly: true
+        type: string
+      subject:
+        type: string
+    x-okta-tags:
+      - Brands
+  EmailTemplateCustomizationRequest:
+    properties:
+      body:
+        type: string
+      isDefault:
+        format: boolean
+      language:
+        description: unique under each email template
+        type: string
+      subject:
+        type: string
+    x-okta-tags:
+      - Brands
+  EmailTemplateTestRequest:
+    properties:
+      customizationId:
+        type: string
+    x-okta-tags:
+      - Brands
   EmailTemplateTouchPointVariant:
     enum:
       - OKTA_DEFAULT

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -7906,7 +7906,7 @@ paths:
           description: Not Found
       security:
         - api_token: []
-      summary: Subscribe to a specific notification type 
+      summary: Subscribe to a specific notification type
       tags:
         - Subscription
   '/api/v1/users/{userId}/subscriptions/{notificationType}/unsubscribe':
@@ -8340,6 +8340,374 @@ paths:
       security:
         - api_token: []
       summary: Update Brand
+      tags:
+        - Brand
+  '/api/v1/brands/{brandId}/templates/email':
+    get:
+      description: List email templates in your organization with pagination.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: listEmailTemplates
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - description: Specifies the pagination cursor for the next page of email templates.
+          in: query
+          name: after
+          type: string
+        - default: 20
+          description: Specifies the number of results returned (maximum 200)
+          format: int32
+          in: query
+          name: limit
+          type: integer
+      responses:
+        '200':
+          description: Success
+          schema:
+            items:
+              $ref: '#/definitions/EmailTemplate'
+            type: array
+      summary: List Email Templates
+      security:
+        - api_token: []
+      tags:
+        - Brand
+  '/api/v1/brands/{brandId}/templates/email/{templateName}':
+    get:
+      description: Fetch an email template by templateName
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: getEmailTemplate
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/EmailTemplate'
+      summary: Get Email Template
+      security:
+        - api_token: []
+      tags:
+        - Brand
+  '/api/v1/brands/{brandId}/templates/email/{templateName}/customizations':
+    get:
+      description: List all email customizations for an email template
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: listEmailTemplateCustomizations
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+      responses:
+
+        '200':
+          description: Success
+          schema:
+            items:
+              $ref: '#/definitions/EmailTemplateCustomizationRequest'
+            type: array
+      summary: List Email Template Customization
+      security:
+        - api_token: []
+      tags:
+        - Brand
+    post:
+      description: Create an email customization
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: createEmailTemplateCustomization
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+        - in: body
+          name: customization
+          required: true
+          schema:
+            $ref: '#/definitions/EmailTemplateCustomizationRequest'
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/EmailTemplateCustomization'
+        '409':
+          description: Conflict
+      summary: Create Email Template Customization
+      security:
+        - api_token: []
+      tags:
+        - Brand
+    delete:
+      description: Delete all customizations for an email template. Also known as “Reset to Default”.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: deleteEmailTemplateCustomizations
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+      responses:
+        '204':
+          description: Success
+      summary: Delete Email Template Customization
+      security:
+        - api_token: []
+      tags:
+        - Brand
+  '/api/v1/brands/{brandId}/templates/email/{templateName}/customizations/{customizationId}':
+    get:
+      description: Fetch an email customization by id.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: getEmailTemplateCustomization
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+        - in: path
+          name: customizationId
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/EmailTemplateCustomization'
+      summary: Get Email Template Customization
+      security:
+        - api_token: []
+      tags:
+        - Brand
+    put:
+      description: Update an email customization
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: updateEmailTemplateCustomization
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+        - in: path
+          name: customizationId
+          required: true
+          type: string
+        - in: body
+          name: customization
+          required: true
+          schema:
+            $ref: '#/definitions/EmailTemplateCustomizationRequest'
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/EmailTemplateCustomization'
+        '409':
+          description: Conflict
+      summary: Update Email Customization
+      security:
+        - api_token: []
+      tags:
+        - Brand
+    delete:
+      description: Delete an email customization
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: deleteEmailTemplateCustomization
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+        - in: path
+          name: customizationId
+          required: true
+          type: string
+      responses:
+        '204':
+          description: No Content
+        '409':
+          description: Conflict
+      summary: Delete Email Customization
+      security:
+        - api_token: []
+      tags:
+        - Brand
+  '/api/v1/brands/{brandId}/templates/email/{templateName}/customizations/{customizationId}/preview':
+    get:
+      description: Get a preview of an email template customization.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: getEmailTemplateCustomizationPreview
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+        - in: path
+          name: customizationId
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/EmailTemplateContent'
+      summary: Get Preview Content of Email Customization
+      security:
+        - api_token: []
+      tags:
+        - Brand
+  '/api/v1/brands/{brandId}/templates/email/{templateName}/default-content':
+    get:
+      description: Fetch the default content for an email template.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: getEmailTemplateDefaultContent
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/EmailTemplateContent'
+      summary: Get Default Content of Email Template
+      security:
+        - api_token: []
+      tags:
+        - Brand
+  '/api/v1/brands/{brandId}/templates/email/{templateName}/default-content/preview':
+    get:
+      description: Fetch a preview of an email template's default content by populating velocity references with the current user's environment.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: getEmailTemplateDefaultContentPreview
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/EmailTemplateContent'
+      summary: Get Preview of Email Template Default Content
+      security:
+        - api_token: []
+      tags:
+        - Brand
+  '/api/v1/brands/{brandId}/templates/email/{templateName}/test':
+    post:
+      description: >-
+        Send a test email to the current users primary and secondary email addresses. The email content is selected based on the following priority:
+          An email customization specifically for the users locale.
+          The default language of email customizations.
+          The email templates default content.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: sendTestEmail
+      parameters:
+        - in: path
+          name: brandId
+          required: true
+          type: string
+        - in: path
+          name: templateName
+          required: true
+          type: string
+        - in: body
+          name: customization
+          required: true
+          schema:
+            $ref: '#/definitions/EmailTemplateTestRequest'
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/EmailTemplateContent'
+      summary: Get Preview of Email Template Default Content
+      security:
+        - api_token: []
       tags:
         - Brand
   '/api/v1/brands/{brandId}/themes':
@@ -16320,3 +16688,106 @@ definitions:
         readOnly: true
     x-okta-tags:
       - Brand
+  EmailTemplate:
+    properties:
+      name:
+        type: string
+        readOnly: true
+      _links:
+        additionalProperties:
+          type: object
+        readOnly: true
+        type: object
+    x-okta-crud:
+      - alias: read
+        operationId: getEmailTemplate
+    x-okta-operations:
+      - alias: getEmailTemplate
+        operationId: getEmailTemplate
+      - alias: deleteEmailTemplateCustomizations
+        operationId: deleteEmailTemplateCustomizations
+      - alias: listEmailTemplateCustomizations
+        operationId: listEmailTemplateCustomizations
+      - alias: createEmailTemplateCustomization
+        operationId: createEmailTemplateCustomization
+      - alias: deleteEmailTemplateCustomization
+        operationId: deleteEmailTemplateCustomization
+      - alias: getEmailTemplateCustomization
+        operationId: getEmailTemplateCustomization
+      - alias: updateEmailTemplateCustomization
+        operationId: updateEmailTemplateCustomization
+      - alias: getEmailTemplateCustomizationPreview
+        operationId: getEmailTemplateCustomizationPreview
+      - alias: getEmailTemplateDefaultContent
+        operationId: getEmailTemplateDefaultContent
+      - alias: getEmailTemplateDefaultContentPreview
+        operationId: getEmailTemplateDefaultContentPreview
+      - alias: sendTestEmail
+        operationId: sendTestEmail
+    x-okta-tags:
+      - Brands
+  EmailTemplateCustomization:
+    properties:
+      body:
+        type: string
+      language:
+        type: string
+        description: unique under each email template
+      subject:
+        type: string
+      id:
+        type: string
+        readOnly: true
+      created:
+        format: date-time
+        readOnly: true
+        type: string
+      isDefault:
+        format: boolean
+      lastUpdated:
+        format: date-time
+        readOnly: true
+        type: string
+      _links:
+        additionalProperties:
+          type: object
+        readOnly: true
+        type: object
+    x-okta-tags:
+      - Brands
+  EmailTemplateCustomizationRequest:
+    properties:
+      body:
+        type: string
+      language:
+        type: string
+        description: unique under each email template
+      subject:
+        type: string
+      isDefault:
+        format: boolean
+    x-okta-tags:
+      - Brands
+  EmailTemplateContent:
+    properties:
+      body:
+        type: string
+      fromAddress:
+        type: string
+      fromName:
+        type: string
+      subject:
+        type: string
+      _links:
+        additionalProperties:
+          type: object
+        readOnly: true
+        type: object
+    x-okta-tags:
+      - Brands
+  EmailTemplateTestRequest:
+    properties:
+      customizationId:
+        type: string
+    x-okta-tags:
+      - Brands

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -8427,7 +8427,7 @@ paths:
           description: Success
           schema:
             items:
-              $ref: '#/definitions/EmailTemplateCustomizationRequest'
+              $ref: '#/definitions/EmailTemplateCustomization'
             type: array
       summary: List Email Template Customization
       security:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -8678,9 +8678,9 @@ paths:
     post:
       description: >-
         Send a test email to the current users primary and secondary email addresses. The email content is selected based on the following priority:
-          An email customization specifically for the users locale.
-          The default language of email customizations.
-          The email templates default content.
+        An email customization specifically for the users locale.
+        The default language of email customizations.
+        The email templates default content.
       consumes:
         - application/json
       produces:
@@ -16743,7 +16743,7 @@ definitions:
         readOnly: true
         type: string
       isDefault:
-        format: boolean
+        type: boolean
       lastUpdated:
         format: date-time
         readOnly: true
@@ -16765,7 +16765,7 @@ definitions:
       subject:
         type: string
       isDefault:
-        format: boolean
+        type: boolean
     x-okta-tags:
       - Brands
   EmailTemplateContent:


### PR DESCRIPTION
### Additions
 - New Paths:
    - `GET /api/v1/brands/{brandId}/templates/email`
        - operation added: `listEmailTemplates`
    - `GET /api/v1/brands/{brandId}/templates/email/{templateName}`
        - operation added: `getEmailTemplate`
    - `DELETE & GET & POST /api/v1/brands/{brandId}/templates/email/{templateName}/customizations`
        - operations added: `deleteEmailTemplateCustomizations`, `listEmailTemplateCustomizations`, `createEmailTemplateCustomization`
    - `DELETE & GET & PUT /api/v1/brands/{brandId}/templates/email/{templateName}/customizations/{customizationId}`
        - operations added: `deleteEmailTemplateCustomization`, `getEmailTemplateCustomization`, `updateEmailTemplateCustomization`
    - `GET /api/v1/brands/{brandId}/templates/email/{templateName}/customizations/{customizationId}/preview`
        - operation added: `getEmailTemplateCustomizationPreview`
    - `GET /api/v1/brands/{brandId}/templates/email/{templateName}/default-content`
        - operation added: `getEmailTemplateDefaultContent`
    - `GET /api/v1/brands/{brandId}/templates/email/{templateName}/default-content/preview`
        - operation added: `getEmailTemplateDefaultContentPreview`
    - `POST /api/v1/brands/{brandId}/templates/email/{templateName}/test`
        - operation added: `sendTestEmail`
 - Models Added:
    - `EmailTemplate`
    - `EmailTemplateCustomization`
    - `EmailTemplateCustomizationRequest`
    - `EmailTemplateContent`
    - `EmailTemplateTestRequest`