### PR TITLE
Redo Apple IDp values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Running changelog of releases since `2.2.3`
 ## 2.11.1
 ### Changes
  - Changes `sendTestEmail` response to a `204 no content` instead of `200 success`
+ - Adds `privateKey` and `teamId` properties to `IdentityProviderCredentialsSigning` to support Apple devices
+ - Adds to `APPLE` to the enums in `FactorProvider' and `LogCredentialProvider
+
 ## 2.11.0
 ### Additions
  - New Paths:

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -17624,7 +17624,8 @@
         "SYMANTEC",
         "DUO",
         "YUBICO",
-        "CUSTOM"
+        "CUSTOM",
+        "APPLE"
       ],
       "type": "string",
       "x-okta-tags": [
@@ -18797,6 +18798,12 @@
       "properties": {
         "kid": {
           "type": "string"
+        },
+        "privateKey": {
+          "type": "string"
+        },
+        "teamId": {
+          "type": "string"
         }
       },
       "type": "object",
@@ -19622,7 +19629,8 @@
         "SYMANTEC",
         "GOOGLE",
         "DUO",
-        "YUBIKEY"
+        "YUBIKEY",
+        "APPLE"
       ],
       "type": "string",
       "x-okta-tags": [

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -11250,6 +11250,7 @@ definitions:
       - DUO
       - YUBICO
       - CUSTOM
+      - APPLE
     type: string
     x-okta-tags:
       - UserFactor
@@ -11996,6 +11997,10 @@ definitions:
     properties:
       kid:
         type: string
+      privateKey:
+        type: string
+      teamId:
+        type: string
     type: object
     x-okta-tags:
       - IdentityProvider
@@ -12544,6 +12549,7 @@ definitions:
       - GOOGLE
       - DUO
       - YUBIKEY
+      - APPLE
     type: string
     x-okta-tags:
       - Log

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -10719,6 +10719,7 @@ definitions:
       - DUO
       - YUBICO
       - CUSTOM
+      - APPLE
     type: string
     x-okta-tags:
       - UserFactor
@@ -11455,6 +11456,10 @@ definitions:
   IdentityProviderCredentialsSigning:
     properties:
       kid:
+        type: string
+      privateKey:
+        type: string
+      teamId:
         type: string
     type: object
     x-okta-tags:
@@ -12925,6 +12930,7 @@ definitions:
       - GOOGLE
       - DUO
       - YUBIKEY
+      - APPLE
     type: string
     x-okta-tags:
       - Log


### PR DESCRIPTION
Avoiding merge commit hassles and redoing PR #110

https://developer.okta.com/docs/reference/api/idps/#add-apple-identity-provider

Related to https://github.com/okta/terraform-provider-okta/issues/841

- Adds `privateKey` and `teamId` to `IdentityProviderCredentialsSigning`
- Adds to `APPLE` to the enum in `FactorProvider`
- Adds to `APPLE` to the enum in `LogCredentialProvider` 