### PR TITLE
chore: add homepage and repository fields in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "@okta/openapi",
   "version": "2.12.0",
   "description": "Utilities to generate OpenAPI specifications for the Okta API",
+  "homepage": "https://github.com/okta/okta-management-openapi-spec",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/okta/okta-management-openapi-spec.git"
+  },
   "main": "./dist/spec.json",
   "bin": {
     "okta-sdk-generator": "lib/generator.js"


### PR DESCRIPTION
With these fields npm package page can link to the public github repo.