### PR TITLE
LinkedObjects ResponseLinks have _links properties.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 Running changelog of releases since `2.2.3`
 
+## 2.11.1
+### Changes
+ - Changes `sendTestEmail` response to a `204 no content` instead of `200 success`
+ - Adds `privateKey` and `teamId` properties to `IdentityProviderCredentialsSigning` to support Apple devices
+ - Adds to `APPLE` to the enums in `FactorProvider' and `LogCredentialProvider
+
 ## 2.11.0
 ### Additions
  - New Paths:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Running changelog of releases since `2.2.3`
 
+## 2.11.2
+### Changes
+ - Add `_links` property to `ResposeLinks` model
+
 ## 2.11.1
 ### Changes
  - Changes `sendTestEmail` response to a `204 no content` instead of `200 success`

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -13,7 +13,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "2.11.0"
+    "version": "2.11.1"
   },
   "externalDocs": {
     "description": "Find more info here",
@@ -4448,11 +4448,8 @@
           "application/json"
         ],
         "responses": {
-          "200": {
-            "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/EmailTemplateContent"
-            }
+          "204": {
+            "description": "No Content"
           }
         },
         "security": [
@@ -17627,7 +17624,8 @@
         "SYMANTEC",
         "DUO",
         "YUBICO",
-        "CUSTOM"
+        "CUSTOM",
+        "APPLE"
       ],
       "type": "string",
       "x-okta-tags": [
@@ -18800,6 +18798,12 @@
       "properties": {
         "kid": {
           "type": "string"
+        },
+        "privateKey": {
+          "type": "string"
+        },
+        "teamId": {
+          "type": "string"
         }
       },
       "type": "object",
@@ -19625,7 +19629,8 @@
         "SYMANTEC",
         "GOOGLE",
         "DUO",
-        "YUBIKEY"
+        "YUBIKEY",
+        "APPLE"
       ],
       "type": "string",
       "x-okta-tags": [

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -13,7 +13,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "2.11.1"
+    "version": "2.11.2"
   },
   "externalDocs": {
     "description": "Find more info here",
@@ -23169,7 +23169,15 @@
       ]
     },
     "ResponseLinks": {
-      "properties": {},
+      "properties": {
+        "_links": {
+          "additionalProperties": {
+            "type": "object"
+          },
+          "readOnly": true,
+          "type": "object"
+        }
+      },
       "type": "object",
       "x-okta-tags": [
         "User"

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -25,7 +25,7 @@ info:
   license:
     name: Apache-2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
-  version: 2.11.0
+  version: 2.11.1
 externalDocs:
   description: Find more info here
   url: 'https://developer.okta.com/docs/api/getting_started/design_principles.html'
@@ -2839,10 +2839,8 @@ paths:
       produces:
         - application/json
       responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/EmailTemplateContent'
+        '204':
+          description: No Content
       security:
         - api_token: []
       summary: Get Preview of Email Template Default Content
@@ -11252,6 +11250,7 @@ definitions:
       - DUO
       - YUBICO
       - CUSTOM
+      - APPLE
     type: string
     x-okta-tags:
       - UserFactor
@@ -11998,6 +11997,10 @@ definitions:
     properties:
       kid:
         type: string
+      privateKey:
+        type: string
+      teamId:
+        type: string
     type: object
     x-okta-tags:
       - IdentityProvider
@@ -12546,6 +12549,7 @@ definitions:
       - GOOGLE
       - DUO
       - YUBIKEY
+      - APPLE
     type: string
     x-okta-tags:
       - Log

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -25,7 +25,7 @@ info:
   license:
     name: Apache-2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
-  version: 2.11.1
+  version: 2.11.2
 externalDocs:
   description: Find more info here
   url: 'https://developer.okta.com/docs/api/getting_started/design_principles.html'
@@ -14898,7 +14898,12 @@ definitions:
     x-okta-tags:
       - User
   ResponseLinks:
-    properties: {}
+    properties:
+      _links:
+        additionalProperties:
+          type: object
+        readOnly: true
+        type: object
     type: object
     x-okta-tags:
       - User

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -137,6 +137,7 @@ function buildOperations(spec) {
       'tags',
       'consumes',
       'produces',
+      'responses',
       'encoding',
       'parameters'
     ]));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/openapi",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "Utilities to generate OpenAPI specifications for the Okta API",
   "main": "./dist/spec.json",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/openapi",
-  "version": "2.12.0",
+  "version": "2.11.2",
   "description": "Utilities to generate OpenAPI specifications for the Okta API",
   "main": "./dist/spec.json",
   "bin": {

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -8701,10 +8701,8 @@ paths:
           schema:
             $ref: '#/definitions/EmailTemplateTestRequest'
       responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/EmailTemplateContent'
+        '204':
+          description: No Content
       summary: Get Preview of Email Template Default Content
       security:
         - api_token: []
@@ -10721,6 +10719,7 @@ definitions:
       - DUO
       - YUBICO
       - CUSTOM
+      - APPLE
     type: string
     x-okta-tags:
       - UserFactor
@@ -11457,6 +11456,10 @@ definitions:
   IdentityProviderCredentialsSigning:
     properties:
       kid:
+        type: string
+      privateKey:
+        type: string
+      teamId:
         type: string
     type: object
     x-okta-tags:
@@ -12927,6 +12930,7 @@ definitions:
       - GOOGLE
       - DUO
       - YUBIKEY
+      - APPLE
     type: string
     x-okta-tags:
       - Log

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -14928,7 +14928,12 @@ definitions:
     x-okta-tags:
       - User
   ResponseLinks:
-    properties: { }
+    properties:
+      _links:
+        additionalProperties:
+          type: object
+        readOnly: true
+        type: object
     type: object
     x-okta-tags:
       - User


### PR DESCRIPTION
`_links` property was omitted from ResponseLinks spec for `GET /api/v1/users/${id}/linkedObjects/${associated.name}` https://developer.okta.com/docs/reference/api/linked-objects/#get-associated-linked-object-values

Tested out in okta-sdk-golang
https://github.com/okta/okta-sdk-golang/pull/285
and okta terraform provider
https://github.com/okta/terraform-provider-okta/pull/1001/files
https://github.com/okta/terraform-provider-okta/blob/7ccb6effb57da5b8fef2860bd286e53f10b05da0/okta/resource_okta_link_value.go#L88