### PR TITLE
Linked objects response links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Running changelog of releases since `2.2.3`
 
 ## 2.11.2
 ### Changes
- - Add `_links` property to `ResposeLinks` model
+ - Add `_links` property to `ResponseLinks` model
 
 ## 2.11.1
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Running changelog of releases since `2.2.3`
 
+## 2.11.2
+### Changes
+ - Add `_links` property to `ResposeLinks` model
+
 ## 2.11.1
 ### Changes
  - Changes `sendTestEmail` response to a `204 no content` instead of `200 success`

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -13,7 +13,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "2.11.1"
+    "version": "2.11.2"
   },
   "externalDocs": {
     "description": "Find more info here",
@@ -23169,7 +23169,15 @@
       ]
     },
     "ResponseLinks": {
-      "properties": {},
+      "properties": {
+        "_links": {
+          "additionalProperties": {
+            "type": "object"
+          },
+          "readOnly": true,
+          "type": "object"
+        }
+      },
       "type": "object",
       "x-okta-tags": [
         "User"

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -25,7 +25,7 @@ info:
   license:
     name: Apache-2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
-  version: 2.11.1
+  version: 2.11.2
 externalDocs:
   description: Find more info here
   url: 'https://developer.okta.com/docs/api/getting_started/design_principles.html'
@@ -14898,7 +14898,12 @@ definitions:
     x-okta-tags:
       - User
   ResponseLinks:
-    properties: {}
+    properties:
+      _links:
+        additionalProperties:
+          type: object
+        readOnly: true
+        type: object
     type: object
     x-okta-tags:
       - User

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/openapi",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "Utilities to generate OpenAPI specifications for the Okta API",
   "main": "./dist/spec.json",
   "bin": {

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -14928,7 +14928,12 @@ definitions:
     x-okta-tags:
       - User
   ResponseLinks:
-    properties: { }
+    properties:
+      _links:
+        additionalProperties:
+          type: object
+        readOnly: true
+        type: object
     type: object
     x-okta-tags:
       - User


### PR DESCRIPTION
`_links` property was omitted from ResponseLinks spec for `GET /api/v1/users/${id}/linkedObjects/${associated.name}` https://developer.okta.com/docs/reference/api/linked-objects/#get-associated-linked-object-values

Tested out in okta-sdk-golang
https://github.com/okta/okta-sdk-golang/pull/285
and okta terraform provider
https://github.com/okta/terraform-provider-okta/pull/1001/files
https://github.com/okta/terraform-provider-okta/blob/7ccb6effb57da5b8fef2860bd286e53f10b05da0/okta/resource_okta_link_value.go#L88