### PR TITLE
Duo authenticator properties

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -13,7 +13,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "2.12.1"
+    "version": "2.13.0"
   },
   "externalDocs": {
     "description": "Find more info here",
@@ -15628,10 +15628,19 @@
         "authPort": {
           "type": "integer"
         },
+        "host": {
+          "type": "string"
+        },
         "hostName": {
           "type": "string"
         },
         "instanceId": {
+          "type": "string"
+        },
+        "integrationKey": {
+          "type": "string"
+        },
+        "secretKey": {
           "type": "string"
         },
         "sharedSecret": {

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -25,7 +25,7 @@ info:
   license:
     name: Apache-2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
-  version: 2.12.1
+  version: 2.13.0
 externalDocs:
   description: Find more info here
   url: 'https://developer.okta.com/docs/api/getting_started/design_principles.html'
@@ -10013,9 +10013,15 @@ definitions:
     properties:
       authPort:
         type: integer
+      host:
+        type: string
       hostName:
         type: string
       instanceId:
+        type: string
+      integrationKey:
+        type: string
+      secretKey:
         type: string
       sharedSecret:
         type: string

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -9876,6 +9876,12 @@ definitions:
         type: string
       userNameTemplate:
         $ref: '#/definitions/AuthenticatorProviderConfigurationUserNamePlate'
+      host:
+        type: string
+      secretKey:
+        type: string
+      integrationKey:
+        type: string
     x-okta-tags:
       - Authenticator
   AuthenticatorProviderConfigurationUserNamePlate:


### PR DESCRIPTION
Authenticator properties specific to the Duo authenticator. They are publicly documented in the Okta API docs.

Properties
- `provider.configuration.host`
- `provider.configuration.integrationKey`
- `provider.configuration.secretKey`

References
- Okta Dev Docs https://github.com/okta/okta-developer-docs/pull/3381
- Published Okta Dev Docs https://developer.okta.com/docs/reference/api/authenticators-admin/#authenticator-object
- okta-sdk-golang generated from this spec https://github.com/okta/okta-sdk-golang/pull/311