### PR TITLE
Add attribute uiSchemaId to the Profile Enrollment Action Object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Running changelog of releases since `2.2.3`
 
  - Added `/api/v1/apps/${applicationId}/credentials/secrets` endpoints and `ClientSecret` model by @monde in https://github.com/okta/okta-management-openapi-spec/pull/146
  - Added property `pkce_required` to `ApplicationCredentialsOAuthClient` model by @monde in https://github.com/okta/okta-management-openapi-spec/pull/145
+ - Added `uiSchemaId` property to the `ProfileEnrollmentPolicyRuleAction` model by @emanor-okta in https://github.com/okta/okta-management-openapi-spec/pull/144
 
 ### Bug fixes
 

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -22630,6 +22630,9 @@
           },
           "type": "array"
         },
+        "uiSchemaId": {
+          "type": "string"
+        },
         "unknownUserAction": {
           "type": "string"
         }

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -14545,6 +14545,8 @@ definitions:
         items:
           type: string
         type: array
+      uiSchemaId:
+        type: string
       unknownUserAction:
         type: string
     type: object

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -11927,6 +11927,8 @@ definitions:
         type: array
       unknownUserAction:
         type: string
+      uiSchemaId:
+        type: string
     type: object
     x-okta-tags:
       - Policy


### PR DESCRIPTION
Add attribute uiSchemaId to the Profile Enrollment Action Object

Ref: https://github.com/okta/okta-developer-docs/pull/3529

API docs: [Profile Enrollment Action object](https://developer.okta.com/docs/reference/api/policy/#profile-enrollment-action-object)
