### PR TITLE
ApplicationCredentialsOAuthClient `pkce_required` boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 Running changelog of releases since `2.2.3`
 
+## 2.15.0
+
+### Additions
+ - Added property `pkce_required` to `ApplicationCredentialsOAuthClient` model
+
 ## 2.13.0
 
 ### Additions

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -15163,6 +15163,9 @@
         "client_secret": {
           "type": "string"
         },
+        "pkce_required": {
+          "type": "boolean"
+        },
         "token_endpoint_auth_method": {
           "$ref": "#/definitions/OAuthEndpointAuthenticationMethod"
         }

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -9711,6 +9711,8 @@ definitions:
         type: string
       client_secret:
         type: string
+      pkce_required:
+        type: boolean
       token_endpoint_auth_method:
         $ref: '#/definitions/OAuthEndpointAuthenticationMethod'
     x-okta-tags:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -9568,6 +9568,8 @@ definitions:
         type: string
       client_secret:
         type: string
+      pkce_required:
+        type: boolean
       token_endpoint_auth_method:
         $ref: '#/definitions/OAuthEndpointAuthenticationMethod'
     x-okta-tags:


### PR DESCRIPTION
Adds `pkce_required` boolean which is now present on the `ApplicationCredentialsOAuthClient` model

https://developer.okta.com/docs/reference/api/apps/#oauth-credential-object

okta-sdk-golang https://github.com/okta/okta-sdk-golang/pull/329