### PR TITLE
Adding new OAuthGrantTypes

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -13,7 +13,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "2.14.0"
+    "version": "2.15.0"
   },
   "externalDocs": {
     "description": "Find more info here",
@@ -20707,7 +20707,11 @@
         "implicit",
         "password",
         "refresh_token",
-        "client_credentials"
+        "client_credentials",
+        "saml2_bearer",
+        "device_code",
+        "token_exchange",
+        "interaction_code"
       ],
       "type": "string",
       "x-okta-tags": [

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -25,7 +25,7 @@ info:
   license:
     name: Apache-2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
-  version: 2.14.0
+  version: 2.15.0
 externalDocs:
   description: Find more info here
   url: 'https://developer.okta.com/docs/api/getting_started/design_principles.html'
@@ -13297,6 +13297,10 @@ definitions:
       - password
       - refresh_token
       - client_credentials
+      - saml2_bearer
+      - device_code
+      - token_exchange
+      - interaction_code
     type: string
     x-okta-tags:
       - Application

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -13670,6 +13670,10 @@ definitions:
       - password
       - refresh_token
       - client_credentials
+      - saml2_bearer
+      - device_code
+      - token_exchange
+      - interaction_code
     type: string
     x-okta-tags:
       - Application


### PR DESCRIPTION
Problem:
Python SDK does not have the urn:ietf:params:oauth:grant-type:saml2-bearer [OAuthGrantType here](https://github.com/okta/okta-sdk-python/blob/46184663baccb926dc14ab964dfd9406d375de0a/okta/models/o_auth_grant_type.py#L24-L36) that the customer cannot create such an OAuth2 Client using the Python SDK.

This PR adds the missing SAML2Bearer grant type and a few other which were also missing:
- urn:ietf:params:oauth:grant-type:device_code
- urn:ietf:params:oauth:grant-type:saml2-bearer
- urn:ietf:params:oauth:grant-type:token-exchange
- interaction_code

