### PR TITLE
Support `POST /api/v1/authenticators`

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -2241,7 +2241,7 @@
         "consumes": [
           "application/json"
         ],
-        "description": "Success",
+        "description": "List Authenticators",
         "operationId": "listAuthenticators",
         "parameters": [],
         "produces": [
@@ -2263,6 +2263,49 @@
             "api_token": []
           }
         ],
+        "summary": "Lists all available Authenticators",
+        "tags": [
+          "Authenticator"
+        ]
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Create Authenticator",
+        "operationId": "createAuthenticator",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "activate",
+            "type": "boolean"
+          },
+          {
+            "in": "body",
+            "name": "authenticator",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Authenticator"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Authenticator"
+            }
+          }
+        },
+        "security": [
+          {
+            "api_token": []
+          }
+        ],
+        "summary": "Create an Authenticator",
         "tags": [
           "Authenticator"
         ]

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -1443,7 +1443,7 @@ paths:
     get:
       consumes:
         - application/json
-      description: Success
+      description: List Authenticators
       operationId: listAuthenticators
       parameters: []
       produces:
@@ -1457,6 +1457,33 @@ paths:
             type: array
       security:
         - api_token: []
+      summary: Lists all available Authenticators
+      tags:
+        - Authenticator
+    post:
+      consumes:
+        - application/json
+      description: Create Authenticator
+      operationId: createAuthenticator
+      parameters:
+        - in: query
+          name: activate
+          type: boolean
+        - in: body
+          name: authenticator
+          required: true
+          schema:
+            $ref: '#/definitions/Authenticator'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/Authenticator'
+      security:
+        - api_token: []
+      summary: Create an Authenticator
       tags:
         - Authenticator
   '/api/v1/authenticators/{authenticatorId}':

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -1421,7 +1421,8 @@ paths:
     get:
       consumes:
         - application/json
-      description: Success
+      description: List Authenticators
+      summary: Lists all available Authenticators
       operationId: listAuthenticators
       parameters: []
       produces:
@@ -1433,6 +1434,32 @@ paths:
             items:
               $ref: '#/definitions/Authenticator'
             type: array
+      security:
+        - api_token: []
+      tags:
+        - Authenticator
+    post:
+      consumes:
+        - application/json
+      description: Create Authenticator
+      summary: Create an Authenticator
+      operationId: createAuthenticator
+      parameters:
+        - in: query
+          name: activate
+          type: boolean
+        - in: body
+          name: authenticator
+          required: true
+          schema:
+            $ref: '#/definitions/Authenticator'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/Authenticator'
       security:
         - api_token: []
       tags:


### PR DESCRIPTION
Support `POST /api/v1/authenticators`
https://developer.okta.com/docs/reference/api/authenticators-admin/#create-authenticator

Proven in:

- https://github.com/okta/okta-sdk-golang/pull/345
- https://github.com/okta/terraform-provider-okta/pull/1379