### PR TITLE
Adding samlSignedRequestEnabled boolean field to SAML app settings

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -13,7 +13,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "2.15.0"
+    "version": "2.16.0"
   },
   "externalDocs": {
     "description": "Find more info here",
@@ -23908,6 +23908,9 @@
           "type": "boolean"
         },
         "responseSigned": {
+          "type": "boolean"
+        },
+        "samlSignedRequestEnabled": {
           "type": "boolean"
         },
         "signatureAlgorithm": {

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -25,7 +25,7 @@ info:
   license:
     name: Apache-2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
-  version: 2.15.0
+  version: 2.16.0
 externalDocs:
   description: Find more info here
   url: 'https://developer.okta.com/docs/api/getting_started/design_principles.html'
@@ -15376,6 +15376,8 @@ definitions:
       requestCompressed:
         type: boolean
       responseSigned:
+        type: boolean
+      samlSignedRequestEnabled:
         type: boolean
       signatureAlgorithm:
         type: string

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -15401,6 +15401,8 @@ definitions:
         type: boolean
       responseSigned:
         type: boolean
+      samlSignedRequestEnabled:
+        type: boolean
       signatureAlgorithm:
         type: string
       slo:


### PR DESCRIPTION
This is a public field and needed by the TF provider https://github.com/okta/terraform-provider-okta/issues/1401

Tests are passing for golang SDK feature branch that makes uses of this spec: [[URL to feature branch]](https://github.com/okta/okta-sdk-golang/pull/361)