### PR TITLE
Add MFA_ENROLL policy type

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -13,7 +13,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "2.15.0"
+    "version": "2.16.0"
   },
   "externalDocs": {
     "description": "Find more info here",
@@ -20508,21 +20508,6 @@
         "Policy"
       ]
     },
-    "MultifactorEnrollmentPolicyRule": {
-      "properties": {
-        "actions": {
-          "$ref": "#/definitions/ProfileEnrollmentPolicyRuleActions"
-        },
-        "name": {
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "x-okta-parent": "#/definitions/PolicyRule",
-      "x-okta-tags": [
-        "Policy"
-      ]
-    },
     "MultifactorEnrollmentPolicySettings": {
       "properties": {
         "authenticators": {
@@ -22839,7 +22824,6 @@
       "x-openapi-v3-discriminator": {
         "mapping": {
           "ACCESS_POLICY": "#/definitions/AccessPolicyRule",
-          "MFA_ENROLL": "#/definitions/MultifactorEnrollmentPolicyRule",
           "PASSWORD": "#/definitions/PasswordPolicyRule",
           "PROFILE_ENROLLMENT": "#/definitions/ProfileEnrollmentPolicyRule",
           "SIGN_ON": "#/definitions/OktaSignOnPolicyRule"

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -22744,10 +22744,7 @@
         "type": {
           "enum": [
             "SIGN_ON",
-            "PASSWORD",
-            "IDP_DISCOVERY",
-            "ACCESS_POLICY",
-            "PROFILE_ENROLLMENT"
+            "PASSWORD"
           ],
           "type": "string"
         }

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -22745,7 +22745,6 @@
           "enum": [
             "SIGN_ON",
             "PASSWORD",
-            "MFA_ENROLL",
             "IDP_DISCOVERY",
             "ACCESS_POLICY",
             "PROFILE_ENROLLMENT"

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -20415,6 +20415,140 @@
         "Policy"
       ]
     },
+    "MultifactorEnrollmentPolicy": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Policy"
+        },
+        {
+          "properties": {
+            "conditions": {
+              "$ref": "#/definitions/PolicyRuleConditions"
+            },
+            "settings": {
+              "$ref": "#/definitions/MultifactorEnrollmentPolicySettings"
+            }
+          },
+          "type": "object"
+        }
+      ],
+      "x-okta-parent": "#/definitions/Policy",
+      "x-okta-tags": [
+        "Policy"
+      ]
+    },
+    "MultifactorEnrollmentPolicyAuthenticatorSettings": {
+      "properties": {
+        "constraints": {
+          "minimum": 0,
+          "properties": {
+            "aaguidGroups": {
+              "items": {
+                "type": "string",
+                "uniqueItems": true
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "x-okta-lifecycle": {
+            "features": [
+              "WEBAUTHN_MDS_CATALOG_BASED_AAGUID_ALLOWLIST"
+            ]
+          }
+        },
+        "enroll": {
+          "properties": {
+            "self": {
+              "$ref": "#/definitions/MultifactorEnrollmentPolicyAuthenticatorStatus"
+            }
+          },
+          "type": "object"
+        },
+        "key": {
+          "$ref": "#/definitions/MultifactorEnrollmentPolicyAuthenticatorType"
+        }
+      },
+      "type": "object",
+      "x-okta-tags": [
+        "Policy"
+      ]
+    },
+    "MultifactorEnrollmentPolicyAuthenticatorStatus": {
+      "enum": [
+        "NOT_ALLOWED",
+        "OPTIONAL",
+        "REQUIRED"
+      ],
+      "type": "string",
+      "x-okta-tags": [
+        "Policy"
+      ]
+    },
+    "MultifactorEnrollmentPolicyAuthenticatorType": {
+      "enum": [
+        "custom_app",
+        "custom_otp",
+        "duo",
+        "external_idp",
+        "google_otp",
+        "okta_email",
+        "okta_password",
+        "okta_verify",
+        "onprem_mfa",
+        "phone_number",
+        "rsa_token",
+        "security_question",
+        "symantec_vip",
+        "webauthn",
+        "yubikey_token"
+      ],
+      "type": "string",
+      "x-okta-tags": [
+        "Policy"
+      ]
+    },
+    "MultifactorEnrollmentPolicyRule": {
+      "properties": {
+        "actions": {
+          "$ref": "#/definitions/ProfileEnrollmentPolicyRuleActions"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-okta-parent": "#/definitions/PolicyRule",
+      "x-okta-tags": [
+        "Policy"
+      ]
+    },
+    "MultifactorEnrollmentPolicySettings": {
+      "properties": {
+        "authenticators": {
+          "items": {
+            "$ref": "#/definitions/MultifactorEnrollmentPolicyAuthenticatorSettings"
+          },
+          "type": "array"
+        },
+        "type": {
+          "$ref": "#/definitions/MultifactorEnrollmentPolicySettingsType"
+        }
+      },
+      "type": "object",
+      "x-okta-tags": [
+        "Policy"
+      ]
+    },
+    "MultifactorEnrollmentPolicySettingsType": {
+      "enum": [
+        "AUTHENTICATORS"
+      ],
+      "type": "string",
+      "x-okta-tags": [
+        "Policy"
+      ]
+    },
     "NetworkZone": {
       "properties": {
         "_links": {
@@ -22489,6 +22623,7 @@
         "mapping": {
           "ACCESS_POLICY": "#/definitions/AccessPolicy",
           "IDP_DISCOVERY": "#/definitions/IdentityProviderPolicy",
+          "MFA_ENROLL": "#/definitions/MultifactorEnrollmentPolicy",
           "OAUTH_AUTHORIZATION_POLICY": "#/definitions/OAuthAuthorizationPolicy",
           "OKTA_SIGN_ON": "#/definitions/OktaSignOnPolicy",
           "PASSWORD": "#/definitions/PasswordPolicy",
@@ -22624,7 +22759,11 @@
         "type": {
           "enum": [
             "SIGN_ON",
-            "PASSWORD"
+            "PASSWORD",
+            "MFA_ENROLL",
+            "IDP_DISCOVERY",
+            "ACCESS_POLICY",
+            "PROFILE_ENROLLMENT"
           ],
           "type": "string"
         }
@@ -22700,6 +22839,7 @@
       "x-openapi-v3-discriminator": {
         "mapping": {
           "ACCESS_POLICY": "#/definitions/AccessPolicyRule",
+          "MFA_ENROLL": "#/definitions/MultifactorEnrollmentPolicyRule",
           "PASSWORD": "#/definitions/PasswordPolicyRule",
           "PROFILE_ENROLLMENT": "#/definitions/ProfileEnrollmentPolicyRule",
           "SIGN_ON": "#/definitions/OktaSignOnPolicyRule"
@@ -22886,7 +23026,8 @@
         "PASSWORD",
         "IDP_DISCOVERY",
         "PROFILE_ENROLLMENT",
-        "ACCESS_POLICY"
+        "ACCESS_POLICY",
+        "MFA_ENROLL"
       ],
       "type": "string",
       "x-okta-tags": [

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -13080,6 +13080,97 @@ definitions:
     type: object
     x-okta-tags:
       - Policy
+  MultifactorEnrollmentPolicy:
+    allOf:
+      - $ref: '#/definitions/Policy'
+      - properties:
+          conditions:
+            $ref: '#/definitions/PolicyRuleConditions'
+          settings:
+            $ref: '#/definitions/MultifactorEnrollmentPolicySettings'
+        type: object
+    x-okta-parent: '#/definitions/Policy'
+    x-okta-tags:
+      - Policy
+  MultifactorEnrollmentPolicyAuthenticatorSettings:
+    properties:
+      constraints:
+        minimum: 0
+        properties:
+          aaguidGroups:
+            items:
+              type: string
+              uniqueItems: true
+            type: array
+        type: object
+        x-okta-lifecycle:
+          features:
+            - WEBAUTHN_MDS_CATALOG_BASED_AAGUID_ALLOWLIST
+      enroll:
+        properties:
+          self:
+            $ref: '#/definitions/MultifactorEnrollmentPolicyAuthenticatorStatus'
+        type: object
+      key:
+        $ref: '#/definitions/MultifactorEnrollmentPolicyAuthenticatorType'
+    type: object
+    x-okta-tags:
+      - Policy
+  MultifactorEnrollmentPolicyAuthenticatorStatus:
+    enum:
+      - NOT_ALLOWED
+      - OPTIONAL
+      - REQUIRED
+    type: string
+    x-okta-tags:
+      - Policy
+  MultifactorEnrollmentPolicyAuthenticatorType:
+    enum:
+      - custom_app
+      - custom_otp
+      - duo
+      - external_idp
+      - google_otp
+      - okta_email
+      - okta_password
+      - okta_verify
+      - onprem_mfa
+      - phone_number
+      - rsa_token
+      - security_question
+      - symantec_vip
+      - webauthn
+      - yubikey_token
+    type: string
+    x-okta-tags:
+      - Policy
+  MultifactorEnrollmentPolicyRule:
+    properties:
+      actions:
+        $ref: '#/definitions/ProfileEnrollmentPolicyRuleActions'
+      name:
+        type: string
+    type: object
+    x-okta-parent: '#/definitions/PolicyRule'
+    x-okta-tags:
+      - Policy
+  MultifactorEnrollmentPolicySettings:
+    properties:
+      authenticators:
+        items:
+          $ref: '#/definitions/MultifactorEnrollmentPolicyAuthenticatorSettings'
+        type: array
+      type:
+        $ref: '#/definitions/MultifactorEnrollmentPolicySettingsType'
+    type: object
+    x-okta-tags:
+      - Policy
+  MultifactorEnrollmentPolicySettingsType:
+    enum:
+      - AUTHENTICATORS
+    type: string
+    x-okta-tags:
+      - Policy
   NetworkZone:
     properties:
       _links:
@@ -14450,6 +14541,7 @@ definitions:
       mapping:
         ACCESS_POLICY: '#/definitions/AccessPolicy'
         IDP_DISCOVERY: '#/definitions/IdentityProviderPolicy'
+        MFA_ENROLL: '#/definitions/MultifactorEnrollmentPolicy'
         OAUTH_AUTHORIZATION_POLICY: '#/definitions/OAuthAuthorizationPolicy'
         OKTA_SIGN_ON: '#/definitions/OktaSignOnPolicy'
         PASSWORD: '#/definitions/PasswordPolicy'
@@ -14544,6 +14636,10 @@ definitions:
         enum:
           - SIGN_ON
           - PASSWORD
+          - MFA_ENROLL
+          - IDP_DISCOVERY
+          - ACCESS_POLICY
+          - PROFILE_ENROLLMENT
         type: string
     type: object
     x-okta-crud:
@@ -14583,6 +14679,7 @@ definitions:
     x-openapi-v3-discriminator:
       mapping:
         ACCESS_POLICY: '#/definitions/AccessPolicyRule'
+        MFA_ENROLL: '#/definitions/MultifactorEnrollmentPolicyRule'
         PASSWORD: '#/definitions/PasswordPolicyRule'
         PROFILE_ENROLLMENT: '#/definitions/ProfileEnrollmentPolicyRule'
         SIGN_ON: '#/definitions/OktaSignOnPolicyRule'
@@ -14710,6 +14807,7 @@ definitions:
       - IDP_DISCOVERY
       - PROFILE_ENROLLMENT
       - ACCESS_POLICY
+      - MFA_ENROLL
     type: string
     x-okta-tags:
       - Policy

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -14626,7 +14626,6 @@ definitions:
         enum:
           - SIGN_ON
           - PASSWORD
-          - MFA_ENROLL
           - IDP_DISCOVERY
           - ACCESS_POLICY
           - PROFILE_ENROLLMENT

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -14626,9 +14626,6 @@ definitions:
         enum:
           - SIGN_ON
           - PASSWORD
-          - IDP_DISCOVERY
-          - ACCESS_POLICY
-          - PROFILE_ENROLLMENT
         type: string
     type: object
     x-okta-crud:

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -25,7 +25,7 @@ info:
   license:
     name: Apache-2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
-  version: 2.15.0
+  version: 2.16.0
 externalDocs:
   description: Find more info here
   url: 'https://developer.okta.com/docs/api/getting_started/design_principles.html'
@@ -13144,16 +13144,6 @@ definitions:
     type: string
     x-okta-tags:
       - Policy
-  MultifactorEnrollmentPolicyRule:
-    properties:
-      actions:
-        $ref: '#/definitions/ProfileEnrollmentPolicyRuleActions'
-      name:
-        type: string
-    type: object
-    x-okta-parent: '#/definitions/PolicyRule'
-    x-okta-tags:
-      - Policy
   MultifactorEnrollmentPolicySettings:
     properties:
       authenticators:
@@ -14679,7 +14669,6 @@ definitions:
     x-openapi-v3-discriminator:
       mapping:
         ACCESS_POLICY: '#/definitions/AccessPolicyRule'
-        MFA_ENROLL: '#/definitions/MultifactorEnrollmentPolicyRule'
         PASSWORD: '#/definitions/PasswordPolicyRule'
         PROFILE_ENROLLMENT: '#/definitions/ProfileEnrollmentPolicyRule'
         SIGN_ON: '#/definitions/OktaSignOnPolicyRule'

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -14799,7 +14799,6 @@ definitions:
         enum:
           - SIGN_ON
           - PASSWORD
-          - MFA_ENROLL
           - IDP_DISCOVERY
           - ACCESS_POLICY
           - PROFILE_ENROLLMENT

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -12159,6 +12159,97 @@ definitions:
     type: object
     x-okta-tags:
       - Policy
+  MultifactorEnrollmentPolicy:
+    x-okta-parent: '#/definitions/Policy'
+    x-okta-tags:
+      - Policy
+    allOf:
+      - $ref: '#/definitions/Policy'
+      - type: object
+        properties:
+          conditions:
+            $ref: '#/definitions/PolicyRuleConditions'
+          settings:
+            $ref: '#/definitions/MultifactorEnrollmentPolicySettings'
+  MultifactorEnrollmentPolicyRule:
+    properties:
+      actions:
+        $ref: '#/definitions/ProfileEnrollmentPolicyRuleActions'
+      name:
+        type: string
+    x-okta-parent: '#/definitions/PolicyRule'
+    type: object
+    x-okta-tags:
+      - Policy
+  MultifactorEnrollmentPolicySettings:
+    type: object
+    properties:
+      authenticators:
+        items:
+          $ref: '#/definitions/MultifactorEnrollmentPolicyAuthenticatorSettings'
+        type: array
+      type:
+        $ref: '#/definitions/MultifactorEnrollmentPolicySettingsType'
+    x-okta-tags:
+      - Policy
+  MultifactorEnrollmentPolicySettingsType:
+    type: string
+    enum:
+      - AUTHENTICATORS
+    x-okta-tags:
+      - Policy
+  MultifactorEnrollmentPolicyAuthenticatorStatus:
+    type: string
+    enum:
+      - NOT_ALLOWED
+      - OPTIONAL
+      - REQUIRED
+    x-okta-tags:
+      - Policy
+  MultifactorEnrollmentPolicyAuthenticatorType:
+    type: string
+    enum:
+      - custom_app
+      - custom_otp
+      - duo
+      - external_idp
+      - google_otp
+      - okta_email
+      - okta_password
+      - okta_verify
+      - onprem_mfa
+      - phone_number
+      - rsa_token
+      - security_question
+      - symantec_vip
+      - webauthn
+      - yubikey_token
+    x-okta-tags:
+      - Policy
+  MultifactorEnrollmentPolicyAuthenticatorSettings:
+      type: object
+      properties:
+        constraints:
+          minimum: 0
+          type: object
+          properties:
+            aaguidGroups:
+              type: array
+              items:
+                type: string
+                uniqueItems: true
+          x-okta-lifecycle:
+            features:
+              - WEBAUTHN_MDS_CATALOG_BASED_AAGUID_ALLOWLIST
+        enroll:
+          type: object
+          properties:
+            self:
+              $ref: '#/definitions/MultifactorEnrollmentPolicyAuthenticatorStatus'
+        key:
+          $ref: '#/definitions/MultifactorEnrollmentPolicyAuthenticatorType'
+      x-okta-tags:
+        - Policy
   ProvisioningConnection:
     properties:
       authScheme:
@@ -14634,6 +14725,7 @@ definitions:
         PASSWORD: '#/definitions/PasswordPolicy'
         PROFILE_ENROLLMENT: '#/definitions/ProfileEnrollmentPolicy'
         ACCESS_POLICY: '#/definitions/AccessPolicy'
+        MFA_ENROLL: '#/definitions/MultifactorEnrollmentPolicy'
       propertyName: type
   PolicyAccountLink:
     properties:
@@ -14717,6 +14809,10 @@ definitions:
         enum:
           - SIGN_ON
           - PASSWORD
+          - MFA_ENROLL
+          - IDP_DISCOVERY
+          - ACCESS_POLICY
+          - PROFILE_ENROLLMENT
         type: string
       name:
         type: string
@@ -14765,6 +14861,7 @@ definitions:
         SIGN_ON: '#/definitions/OktaSignOnPolicyRule'
         PROFILE_ENROLLMENT: '#/definitions/ProfileEnrollmentPolicyRule'
         ACCESS_POLICY: '#/definitions/AccessPolicyRule'
+        MFA_ENROLL: '#/definitions/MultifactorEnrollmentPolicyRule'
       propertyName: type
   PolicyRuleAuthContextCondition:
     properties:
@@ -14889,6 +14986,7 @@ definitions:
       - IDP_DISCOVERY
       - PROFILE_ENROLLMENT
       - ACCESS_POLICY
+      - MFA_ENROLL
     type: string
     x-okta-tags:
       - Policy

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -14799,9 +14799,6 @@ definitions:
         enum:
           - SIGN_ON
           - PASSWORD
-          - IDP_DISCOVERY
-          - ACCESS_POLICY
-          - PROFILE_ENROLLMENT
         type: string
       name:
         type: string

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -12171,16 +12171,6 @@ definitions:
             $ref: '#/definitions/PolicyRuleConditions'
           settings:
             $ref: '#/definitions/MultifactorEnrollmentPolicySettings'
-  MultifactorEnrollmentPolicyRule:
-    properties:
-      actions:
-        $ref: '#/definitions/ProfileEnrollmentPolicyRuleActions'
-      name:
-        type: string
-    x-okta-parent: '#/definitions/PolicyRule'
-    type: object
-    x-okta-tags:
-      - Policy
   MultifactorEnrollmentPolicySettings:
     type: object
     properties:
@@ -14861,7 +14851,6 @@ definitions:
         SIGN_ON: '#/definitions/OktaSignOnPolicyRule'
         PROFILE_ENROLLMENT: '#/definitions/ProfileEnrollmentPolicyRule'
         ACCESS_POLICY: '#/definitions/AccessPolicyRule'
-        MFA_ENROLL: '#/definitions/MultifactorEnrollmentPolicyRule'
       propertyName: type
   PolicyRuleAuthContextCondition:
     properties:


### PR DESCRIPTION
`MFA_ENROLL` policy type was missing in the spec, this will allow users to get `MFA_ENROLL` policies, referring to this: https://github.com/okta/okta-sdk-python/issues/288

Already implemented in OASV3 - took inspiration from there