### PR TITLE
fix: Add missing default property to AuthorizationServer

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -16038,6 +16038,10 @@
         "credentials": {
           "$ref": "#/definitions/AuthorizationServerCredentials"
         },
+        "default": {
+          "readOnly": true,
+          "type": "boolean"
+        },
         "description": {
           "type": "string"
         },

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -10279,6 +10279,9 @@ definitions:
         type: string
       credentials:
         $ref: '#/definitions/AuthorizationServerCredentials'
+      default:
+        readOnly: true
+        type: boolean
       description:
         type: string
       id:

--- a/resources/3.0/management.yaml
+++ b/resources/3.0/management.yaml
@@ -21198,6 +21198,9 @@ components:
           readOnly: true
         credentials:
           $ref: '#/components/schemas/AuthorizationServerCredentials'
+        default:
+          readOnly: true
+          type: boolean
         description:
           type: string
         id:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -10153,6 +10153,9 @@ definitions:
         type: string
       credentials:
         $ref: '#/definitions/AuthorizationServerCredentials'
+      default:
+        readOnly: true
+        type: boolean
       description:
         type: string
       id:


### PR DESCRIPTION
This PR adds the `default` property of the AuthorizationServer which is missing in the spec, but it's returned by the API.
I would like to have this available in the Okta SDK for Node.js.

Docs: https://developer.okta.com/docs/reference/api/authorization-servers/#authorization-server-properties

<img width="1301" alt="Screenshot 2023-02-16 às 15 05 56" src="https://user-images.githubusercontent.com/656062/219386694-bed8c303-8cdf-4fc8-b8e6-6f8fa4617e02.png">
