### PR TITLE
Fixes for python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Running changelog of releases since `2.2.3`
 
+## 2.16.0
+- Added missing properties to applicationsettingsapplication
+- Added signed_nonce factor type per the reference docs: https://developer.okta.com/docs/reference/api/factors/#factor-type
+
 ## 2.15.0
 
 ### Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Running changelog of releases since `2.2.3`
 
 ## 2.16.0
 - Added missing properties to applicationsettingsapplication
-- Added signed_nonce factor type per the reference docs: https://developer.okta.com/docs/reference/api/factors/#factor-type
+- Added signed_nonce factor type
 
 ## 2.15.0
 

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -18234,6 +18234,7 @@
         "hotp",
         "push",
         "question",
+        "signed_nonce",
         "sms",
         "token:hardware",
         "token:hotp",

--- a/dist/spec.json
+++ b/dist/spec.json
@@ -15803,7 +15803,7 @@
     },
     "ApplicationSettingsApplication": {
       "properties": {
-        "acsURL": {
+        "acsUrl": {
           "type": "string"
         },
         "buttonField": {

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -10121,7 +10121,7 @@ definitions:
       - Application
   ApplicationSettingsApplication:
     properties:
-      acsURL:
+      acsUrl:
         type: string
       buttonField:
         type: string

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -11651,6 +11651,7 @@ definitions:
       - hotp
       - push
       - question
+      - signed_nonce
       - sms
       - 'token:hardware'
       - 'token:hotp'

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -9960,7 +9960,7 @@ definitions:
         type: string
       url:
         type: string
-      acsURL:
+      acsUrl:
         type: string
       buttonField:
         type: string

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -11117,6 +11117,7 @@ definitions:
       - hotp
       - push
       - question
+      - signed_nonce
       - sms
       - 'token:hardware'
       - 'token:hotp'


### PR DESCRIPTION
- Add missing properties to applicationsettingsapplication per the reference docs: https://developer.okta.com/docs/reference/api/apps/#settings-4
- Add signed_nonce factor type per the reference docs: https://developer.okta.com/docs/reference/api/factors/#factor-type

Related to OKTA-588345 and OKTA-588345

Represents python sdk changes made here: https://github.com/okta/okta-sdk-python/pull/366