### PR TITLE
Add FLEXIBLE to Oauth2Scope consent

### DIFF
--- a/dist/spec.json
+++ b/dist/spec.json
@@ -21122,6 +21122,7 @@
           "enum": [
             "REQUIRED",
             "IMPLICIT",
+            "FLEXIBLE",
             "ADMIN"
           ],
           "type": "string"

--- a/dist/spec.yaml
+++ b/dist/spec.yaml
@@ -13555,6 +13555,7 @@ definitions:
         enum:
           - REQUIRED
           - IMPLICIT
+          - FLEXIBLE
           - ADMIN
         type: string
       default:

--- a/resources/spec.yaml
+++ b/resources/spec.yaml
@@ -13931,6 +13931,7 @@ definitions:
         enum:
           - REQUIRED
           - IMPLICIT
+          - FLEXIBLE
           - ADMIN
         type: string
       default:


### PR DESCRIPTION
This is a valid consent type that is present in the current developer documentation:
* https://developer.okta.com/docs/reference/api/oidc/#scope-properties

This is also related to the following terraform provider issue:
* https://github.com/okta/terraform-provider-okta/issues/1661